### PR TITLE
Fix stereo viewport

### DIFF
--- a/Dev/Cpp/common/EffekseerPlugin.cpp
+++ b/Dev/Cpp/common/EffekseerPlugin.cpp
@@ -375,6 +375,13 @@ extern "C"
 
 		// 背景テクスチャを解除
 		SetBackGroundTexture(nullptr);
+
+		// Viewportを初期化
+		RenderSettings& settings = renderSettings[renderId];
+		if (settings.stereoRenderingType == StereoRenderingType::SinglePass)
+		{
+			g_graphics->ShiftViewportForStereoSinglePass(false);
+		}
 	}
 
 	UNITY_INTERFACE_EXPORT void UNITY_INTERFACE_API EffekseerRenderBack(int renderId)
@@ -433,6 +440,11 @@ extern "C"
 			{
 				projectionMatrix = settings.leftProjectionMatrix;
 				cameraMatrix = settings.leftCameraMatrix;
+
+				if (settings.stereoRenderingType == StereoRenderingType::SinglePass)
+				{
+					g_graphics->ShiftViewportForStereoSinglePass(false);
+				}
 			}
 			else if (settings.stereoRenderCount == 1)
 			{
@@ -441,7 +453,7 @@ extern "C"
 
 				if (settings.stereoRenderingType == StereoRenderingType::SinglePass)
 				{
-					g_graphics->ShiftViewportForStereoSinglePass();
+					g_graphics->ShiftViewportForStereoSinglePass(true);
 				}
 			}
 			settings.stereoRenderCount++;

--- a/Dev/Cpp/common/EffekseerPluginCommon.cpp
+++ b/Dev/Cpp/common/EffekseerPluginCommon.cpp
@@ -325,6 +325,7 @@ extern "C"
 	{
 		if (renderId >= 0 && renderId < MAX_RENDER_PATH) {
 			Array2Matrix(renderSettings[renderId].projectionMatrix, matrixArray);
+			renderSettings[renderId].stereoEnabled = false;
 		}
 	}
 	
@@ -333,6 +334,7 @@ extern "C"
 	{
 		if (renderId >= 0 && renderId < MAX_RENDER_PATH) {
 			Array2Matrix(renderSettings[renderId].cameraMatrix, matrixArray);
+			renderSettings[renderId].stereoEnabled = false;
 		}
 	}
 

--- a/Dev/Cpp/graphicsAPI/EffekseerPluginGraphics.h
+++ b/Dev/Cpp/graphicsAPI/EffekseerPluginGraphics.h
@@ -41,7 +41,7 @@ public:
 
 	virtual Effekseer::ModelLoader* Create(ModelLoaderLoad load, ModelLoaderUnload unload) = 0;
 
-	virtual void ShiftViewportForStereoSinglePass() = 0;
+	virtual void ShiftViewportForStereoSinglePass(bool isShift) = 0;
 
 	virtual void StartRender(EffekseerRenderer::Renderer* renderer) {};
 };

--- a/Dev/Cpp/graphicsAPI/EffekseerPluginGraphicsDX11.cpp
+++ b/Dev/Cpp/graphicsAPI/EffekseerPluginGraphicsDX11.cpp
@@ -227,12 +227,15 @@ Effekseer::ModelLoader* GraphicsDX11::Create(ModelLoaderLoad load, ModelLoaderUn
 	return loader;
 }
 
-void GraphicsDX11::ShiftViewportForStereoSinglePass()
+void GraphicsDX11::ShiftViewportForStereoSinglePass(bool isShift)
 {
 	D3D11_VIEWPORT vp;
 	UINT viewportNum = 1;
 	d3d11Context->RSGetViewports(&viewportNum, &vp);
-	vp.TopLeftX = vp.Width;
+	if (isShift)
+		vp.TopLeftX = vp.Width;
+	else
+		vp.TopLeftX = 0;
 	d3d11Context->RSSetViewports(1, &vp);
 }
 

--- a/Dev/Cpp/graphicsAPI/EffekseerPluginGraphicsDX11.h
+++ b/Dev/Cpp/graphicsAPI/EffekseerPluginGraphicsDX11.h
@@ -34,7 +34,7 @@ public:
 
 	Effekseer::ModelLoader* Create(ModelLoaderLoad load, ModelLoaderUnload unload) override;
 
-	void ShiftViewportForStereoSinglePass() override;
+	void ShiftViewportForStereoSinglePass(bool isShift) override;
 };
 
 } // namespace EffekseerPlugin

--- a/Dev/Cpp/graphicsAPI/EffekseerPluginGraphicsDX9.cpp
+++ b/Dev/Cpp/graphicsAPI/EffekseerPluginGraphicsDX9.cpp
@@ -121,11 +121,14 @@ Effekseer::ModelLoader* GraphicsDX9::Create(ModelLoaderLoad load, ModelLoaderUnl
 	return loader;
 }
 
-void GraphicsDX9::ShiftViewportForStereoSinglePass()
+void GraphicsDX9::ShiftViewportForStereoSinglePass(bool isShift)
 {
 	D3DVIEWPORT9 vp;
 	d3d9Device->GetViewport(&vp);
-	vp.X = vp.Width;
+	if (isShift)
+		vp.X = vp.Width;
+	else
+		vp.X = 0;
 	d3d9Device->SetViewport(&vp);
 }
 

--- a/Dev/Cpp/graphicsAPI/EffekseerPluginGraphicsDX9.h
+++ b/Dev/Cpp/graphicsAPI/EffekseerPluginGraphicsDX9.h
@@ -32,7 +32,7 @@ public:
 
 	Effekseer::ModelLoader* Create(ModelLoaderLoad load, ModelLoaderUnload unload) override;
 
-	void ShiftViewportForStereoSinglePass() override;
+	void ShiftViewportForStereoSinglePass(bool isShift) override;
 };
 
 } // namespace EffekseerPlugin

--- a/Dev/Cpp/graphicsAPI/EffekseerPluginGraphicsGL.cpp
+++ b/Dev/Cpp/graphicsAPI/EffekseerPluginGraphicsGL.cpp
@@ -165,11 +165,14 @@ Effekseer::ModelLoader* GraphicsGL::Create(ModelLoaderLoad load, ModelLoaderUnlo
 	return loader;
 }
 
-void GraphicsGL::ShiftViewportForStereoSinglePass()
+void GraphicsGL::ShiftViewportForStereoSinglePass(bool isShift)
 {
 	GLint viewport[4];
 	glGetIntegerv(GL_VIEWPORT, viewport);
-	viewport[0] += viewport[2];
+	if (isShift)
+		viewport[0] = viewport[2];
+	else
+		viewport[0] = 0;
 	glViewport(viewport[0], viewport[1], viewport[2], viewport[3]);
 }
 

--- a/Dev/Cpp/graphicsAPI/EffekseerPluginGraphicsGL.h
+++ b/Dev/Cpp/graphicsAPI/EffekseerPluginGraphicsGL.h
@@ -39,7 +39,7 @@ public:
 
 	Effekseer::ModelLoader* Create(ModelLoaderLoad load, ModelLoaderUnload unload) override;
 
-	void ShiftViewportForStereoSinglePass() override;
+	void ShiftViewportForStereoSinglePass(bool isShift) override;
 };
 
 } // namespace EffekseerPlugin

--- a/Dev/Cpp/graphicsAPI/EffekseerPluginGraphicsUnity.cpp
+++ b/Dev/Cpp/graphicsAPI/EffekseerPluginGraphicsUnity.cpp
@@ -50,7 +50,7 @@ Effekseer::ModelLoader* GraphicsUnity::Create(ModelLoaderLoad load, ModelLoaderU
 	return new EffekseerRendererUnity::ModelLoader(load, unload);
 }
 
-void GraphicsUnity::ShiftViewportForStereoSinglePass() 
+void GraphicsUnity::ShiftViewportForStereoSinglePass(bool isShift) 
 {
 }
 

--- a/Dev/Cpp/graphicsAPI/EffekseerPluginGraphicsUnity.h
+++ b/Dev/Cpp/graphicsAPI/EffekseerPluginGraphicsUnity.h
@@ -30,7 +30,7 @@ public:
 
 	Effekseer::ModelLoader* Create(ModelLoaderLoad load, ModelLoaderUnload unload) override;
 
-	void ShiftViewportForStereoSinglePass() override;
+	void ShiftViewportForStereoSinglePass(bool isShift) override;
 };
 
 } // namespace EffekseerPlugin

--- a/Dev/Plugin/Assets/Effekseer/Scripts/EffekseerRenderer.cs
+++ b/Dev/Plugin/Assets/Effekseer/Scripts/EffekseerRenderer.cs
@@ -1242,8 +1242,8 @@ namespace Effekseer.Internal
 			if (!path.IsValid())
 			{
 				path.Dispose();
-				// var stereoRenderingType = (camera.stereoEnabled) ? StereoRendererUtil.GetStereoRenderingType() : StereoRendererUtil.StereoRenderingTypes.None;
-				path.Init(EffekseerRendererUtils.IsDistortionEnabled, dstID, dstIdentifier, StereoRendererUtil.GetStereoRenderingType());
+				var stereoRenderingType = (camera.stereoEnabled) ? StereoRendererUtil.GetStereoRenderingType() : StereoRendererUtil.StereoRenderingTypes.None;
+				path.Init(EffekseerRendererUtils.IsDistortionEnabled, dstID, dstIdentifier, stereoRenderingType);
 			}
 
 			path.LifeTime = 5;


### PR DESCRIPTION
### 内容
* ShiftViewportForStereoSinglePass(false)でviewportをもとに戻す機能を追加
* 左目描画時にviewportを元に戻す処理を追加
* 非VRカメラのMatrix初期化時にstereoEnabled = falseが入るように修正
  * Unityのシーン切り替えによりrenderIDが入れ替わった場合に、前シーンのVR設定が残ってしまっていた
* stereoRenderingTypeの初期化し忘れを修正
