### PR TITLE
Add null check to EffekseerGetCameraCullingMaskToShowAllEffects

### DIFF
--- a/Dev/Cpp/common/EffekseerPluginCommon.cpp
+++ b/Dev/Cpp/common/EffekseerPluginCommon.cpp
@@ -214,6 +214,10 @@ extern "C"
 	
 	UNITY_INTERFACE_EXPORT int UNITY_INTERFACE_API EffekseerGetCameraCullingMaskToShowAllEffects()
 	{
+		if (g_EffekseerManager == NULL) {
+			return 0;
+		}
+
 		return g_EffekseerManager->GetCameraCullingMaskToShowAllEffects();
 	}
 


### PR DESCRIPTION
`NULL` チェックを `EffekseerGetCameraCullingMaskToShowAllEffects` 関数に追加しました。

他の関数と同様に `NULL` チェック処理を追加したものです。もし不要でしたらクローズしてくださいませ。
