### PR TITLE
Allow Native renderer type for OpenGL ES3

### DIFF
--- a/Dev/Plugin/Assets/Effekseer/Scripts/EffekseerSystem.cs
+++ b/Dev/Plugin/Assets/Effekseer/Scripts/EffekseerSystem.cs
@@ -240,8 +240,7 @@ namespace Effekseer
 
 				if (SystemInfo.supportsComputeShaders)
 				{
-					if (SystemInfo.graphicsDeviceType == GraphicsDeviceType.OpenGLCore ||
-						SystemInfo.graphicsDeviceType == GraphicsDeviceType.OpenGLES3)
+					if (SystemInfo.graphicsDeviceType == GraphicsDeviceType.OpenGLCore)
 					{
 						Debug.LogWarning("[Effekseer] Graphics API \"" + SystemInfo.graphicsDeviceType + "\" has many limitations with ComputeShader. Renderer is changed into Native.");
 						RendererType = EffekseerRendererType.Native;


### PR DESCRIPTION
### 内容
- AndroidビルドのVRモードで正常に描画されなかった問題を修正しました

### 詳細
- `RendererType` を強制的に  `Native` に切り替える条件からOpenGLES3を削除
  - OpenGL ES3.1 の場合ComputeShaderが使えるので `RendererType` が `Unity` でも動作するため
  - OpenGL ES3.0 の場合 ComputeShaderが使えないが  `SystemInfo.supportsComputeShaders` が `false` になるため（Nexus 7 (2013)で確認しました）