### PR TITLE
force to use Native Renderer if OpenGLES 3.0

### DIFF
--- a/Dev/Plugin/Assets/Effekseer/Scripts/EffekseerSystem.cs
+++ b/Dev/Plugin/Assets/Effekseer/Scripts/EffekseerSystem.cs
@@ -298,7 +298,15 @@ namespace Effekseer
 
 				if (SystemInfo.supportsComputeShaders)
 				{
-					if (SystemInfo.graphicsDeviceType == GraphicsDeviceType.OpenGLCore)
+					if (SystemInfo.graphicsDeviceType == GraphicsDeviceType.OpenGLCore ||
+						SystemInfo.graphicsDeviceType == GraphicsDeviceType.OpenGLES3
+#if UNITY_2017_4_OR_NEWER
+						&& !PlayerSettings.openGLRequireES31 && !PlayerSettings.openGLRequireES31AEP
+#endif
+#if UNITY_2019_2_OR_NEWER
+						&& !PlayerSettings.openGLRequireES32
+#endif
+					)
 					{
 						Debug.LogWarning("[Effekseer] Graphics API \"" + SystemInfo.graphicsDeviceType + "\" has many limitations with ComputeShader. Renderer is changed into Native.");
 						RendererType = EffekseerRendererType.Native;


### PR DESCRIPTION
#24 の修正

ComputeShaderが動作するのはOpenGLES3.1以降のため条件を修正