### PR TITLE
Fix #54 for standard effect shaders (Effects on the right eye screen was not rendered when rendering in Single Pass Instanced)

### DIFF
--- a/Dev/Plugin/Assets/Effekseer/Materials/StandardDistortionShader.shader
+++ b/Dev/Plugin/Assets/Effekseer/Materials/StandardDistortionShader.shader
@@ -45,12 +45,12 @@
 
 		float distortionIntensity;
 
-	    struct vs_input
-	    {
-    		uint id : SV_VertexID;
-    		uint inst : SV_InstanceID;
+		struct vs_input
+		{
+			uint id : SV_VertexID;
+			uint inst : SV_InstanceID;
 			UNITY_VERTEX_INPUT_INSTANCE_ID
-	    };
+		};
 
 		struct ps_input
 		{

--- a/Dev/Plugin/Assets/Effekseer/Materials/StandardDistortionShader.shader
+++ b/Dev/Plugin/Assets/Effekseer/Materials/StandardDistortionShader.shader
@@ -45,6 +45,13 @@
 
 		float distortionIntensity;
 
+	    struct vs_input
+	    {
+    		uint id : SV_VertexID;
+    		uint inst : SV_InstanceID;
+			UNITY_VERTEX_INPUT_INSTANCE_ID
+	    };
+
 		struct ps_input
 		{
 			float4 pos : SV_POSITION;
@@ -53,14 +60,19 @@
 			float4 posU : NORMAL2;      // if this name is POS2, something is wrong with Metal API
 			float2 uv : TEXCOORD0;
 			float4 color : COLOR0;
+			UNITY_VERTEX_OUTPUT_STEREO
 		};
 
-		ps_input vert(uint id : SV_VertexID, uint inst : SV_InstanceID)
+		ps_input vert(vs_input i)
 		{
 			ps_input o;
 
-			int qind = (id) / 6;
-			int vind = (id) % 6;
+			UNITY_SETUP_INSTANCE_ID(i);
+			UNITY_INITIALIZE_OUTPUT(ps_input, o);
+			UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+
+			int qind = (i.id) / 6;
+			int vind = (i.id) % 6;
 
 			int v_offset[6];
 			v_offset[0] = 2;

--- a/Dev/Plugin/Assets/Effekseer/Materials/StandardLightingShader.shader
+++ b/Dev/Plugin/Assets/Effekseer/Materials/StandardLightingShader.shader
@@ -80,12 +80,12 @@
 
 		#endif
 
-	    struct vs_input
-	    {
-    		uint id : SV_VertexID;
-    		uint inst : SV_InstanceID;
+		struct vs_input
+		{
+			uint id : SV_VertexID;
+			uint inst : SV_InstanceID;
 			UNITY_VERTEX_INPUT_INSTANCE_ID
-	    };
+		};
 
 		struct ps_input
 		{

--- a/Dev/Plugin/Assets/Effekseer/Materials/StandardLightingShader.shader
+++ b/Dev/Plugin/Assets/Effekseer/Materials/StandardLightingShader.shader
@@ -80,6 +80,13 @@
 
 		#endif
 
+	    struct vs_input
+	    {
+    		uint id : SV_VertexID;
+    		uint inst : SV_InstanceID;
+			UNITY_VERTEX_INPUT_INSTANCE_ID
+	    };
+
 		struct ps_input
 		{
 			float4 Position		: SV_POSITION;
@@ -91,6 +98,7 @@
 			float3 WorldT : TEXCOORD4;
 			float3 WorldB : TEXCOORD5;
 			float2 ScreenUV : TEXCOORD6;
+			UNITY_VERTEX_OUTPUT_STEREO
 		};
 
 		float4 lightDirection;
@@ -109,8 +117,14 @@
 			return uv;
 		}
 
-		ps_input vert(uint id : SV_VertexID, uint inst : SV_InstanceID)
+		ps_input vert(vs_input i)
 		{
+			ps_input Output;
+
+			UNITY_SETUP_INSTANCE_ID(i);
+			UNITY_INITIALIZE_OUTPUT(ps_input, Output);
+			UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(Output);
+
 			// Unity
 			float4 cameraPosition = float4(UNITY_MATRIX_V[3].xyzw);
 
@@ -132,8 +146,8 @@
 
 			#else
 
-			int qind = (id) / 6;
-			int vind = (id) % 6;
+			int qind = (i.id) / 6;
+			int vind = (i.id) % 6;
 
 			int v_offset[6];
 			v_offset[0] = 2;
@@ -146,8 +160,6 @@
 			Vertex Input = buf_vertex[buf_offset + qind * 4 + v_offset[vind]];
 
 			#endif
-
-			ps_input Output;
 
 			#if _MODEL_
 			float3x3 matRotModel = (float3x3)buf_matrix;

--- a/Dev/Plugin/Assets/Effekseer/Materials/StandardModelDistortionShader.shader
+++ b/Dev/Plugin/Assets/Effekseer/Materials/StandardModelDistortionShader.shader
@@ -56,12 +56,12 @@ Properties{
 		StructuredBuffer<int> buf_vertex_offsets;
 		StructuredBuffer<int> buf_index_offsets;
 
-	    struct vs_input
-	    {
-    		uint id : SV_VertexID;
-    		uint inst : SV_InstanceID;
+		struct vs_input
+		{
+			uint id : SV_VertexID;
+			uint inst : SV_InstanceID;
 			UNITY_VERTEX_INPUT_INSTANCE_ID
-	    };
+		};
 
 		struct ps_input
 		{

--- a/Dev/Plugin/Assets/Effekseer/Materials/StandardModelDistortionShader.shader
+++ b/Dev/Plugin/Assets/Effekseer/Materials/StandardModelDistortionShader.shader
@@ -56,6 +56,13 @@ Properties{
 		StructuredBuffer<int> buf_vertex_offsets;
 		StructuredBuffer<int> buf_index_offsets;
 
+	    struct vs_input
+	    {
+    		uint id : SV_VertexID;
+    		uint inst : SV_InstanceID;
+			UNITY_VERTEX_INPUT_INSTANCE_ID
+	    };
+
 		struct ps_input
 		{
 			float4 pos : SV_POSITION;
@@ -64,20 +71,26 @@ Properties{
             float4 posU : NORMAL2;      // if this name is POS2, something is wrong with Metal API
 			float2 uv : TEXCOORD0;
 			float4 color : COLOR0;
+			UNITY_VERTEX_OUTPUT_STEREO
 		};
 
 		float distortionIntensity;
 
-		ps_input vert(uint id : SV_VertexID, uint inst : SV_InstanceID)
+		ps_input vert(vs_input i)
 		{
 			ps_input o;
-			uint v_id = id;
 
-			float4x4 buf_matrix = buf_model_parameter[inst].Mat;
-			float4 buf_uv = buf_model_parameter[inst].UV;
-			float4 buf_color = buf_model_parameter[inst].Color;
-			float buf_vertex_offset = buf_vertex_offsets[buf_model_parameter[inst].Time];
-			float buf_index_offset = buf_index_offsets[buf_model_parameter[inst].Time];
+			UNITY_SETUP_INSTANCE_ID(i);
+			UNITY_INITIALIZE_OUTPUT(ps_input, o);
+			UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+
+			uint v_id = i.id;
+
+			float4x4 buf_matrix = buf_model_parameter[i.inst].Mat;
+			float4 buf_uv = buf_model_parameter[i.inst].UV;
+			float4 buf_color = buf_model_parameter[i.inst].Color;
+			float buf_vertex_offset = buf_vertex_offsets[buf_model_parameter[i.inst].Time];
+			float buf_index_offset = buf_index_offsets[buf_model_parameter[i.inst].Time];
 
 			SimpleVertex v = buf_vertex[buf_index[v_id + buf_index_offset] + buf_vertex_offset];
 

--- a/Dev/Plugin/Assets/Effekseer/Materials/StandardModelShader.shader
+++ b/Dev/Plugin/Assets/Effekseer/Materials/StandardModelShader.shader
@@ -55,23 +55,36 @@ SubShader{
 	StructuredBuffer<int> buf_vertex_offsets;
 	StructuredBuffer<int> buf_index_offsets;
 
+    struct vs_input
+    {
+    	uint id : SV_VertexID;
+    	uint inst : SV_InstanceID;
+		UNITY_VERTEX_INPUT_INSTANCE_ID
+    };
+
 	struct ps_input
 	{
 		float4 pos : SV_POSITION;
 		float2 uv : TEXCOORD0;
 		float4 color : COLOR0;
+		UNITY_VERTEX_OUTPUT_STEREO
 	};
 
-	ps_input vert(uint id : SV_VertexID, uint inst : SV_InstanceID)
+	ps_input vert(vs_input i)
 	{
 		ps_input o;
-		uint v_id = id;
+		
+		UNITY_SETUP_INSTANCE_ID(i);
+		UNITY_INITIALIZE_OUTPUT(ps_input, o);
+		UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
 
-		float4x4 buf_matrix = buf_model_parameter[inst].Mat;
-		float4 buf_uv = buf_model_parameter[inst].UV;
-		float4 buf_color = buf_model_parameter[inst].Color;
-		float buf_vertex_offset = buf_vertex_offsets[buf_model_parameter[inst].Time];
-		float buf_index_offset = buf_index_offsets[buf_model_parameter[inst].Time];
+		uint v_id = i.id;
+
+		float4x4 buf_matrix = buf_model_parameter[i.inst].Mat;
+		float4 buf_uv = buf_model_parameter[i.inst].UV;
+		float4 buf_color = buf_model_parameter[i.inst].Color;
+		float buf_vertex_offset = buf_vertex_offsets[buf_model_parameter[i.inst].Time];
+		float buf_index_offset = buf_index_offsets[buf_model_parameter[i.inst].Time];
 
 		SimpleVertex v = buf_vertex[buf_index[v_id + buf_index_offset] + buf_vertex_offset];
 

--- a/Dev/Plugin/Assets/Effekseer/Materials/StandardModelShader.shader
+++ b/Dev/Plugin/Assets/Effekseer/Materials/StandardModelShader.shader
@@ -55,12 +55,12 @@ SubShader{
 	StructuredBuffer<int> buf_vertex_offsets;
 	StructuredBuffer<int> buf_index_offsets;
 
-    struct vs_input
-    {
-    	uint id : SV_VertexID;
-    	uint inst : SV_InstanceID;
+	struct vs_input
+	{
+		uint id : SV_VertexID;
+		uint inst : SV_InstanceID;
 		UNITY_VERTEX_INPUT_INSTANCE_ID
-    };
+	};
 
 	struct ps_input
 	{

--- a/Dev/Plugin/Assets/Effekseer/Materials/StandardShader.shader
+++ b/Dev/Plugin/Assets/Effekseer/Materials/StandardShader.shader
@@ -43,9 +43,10 @@
     struct vs_input
     {
     	uint id : SV_VertexID;
-        UNITY_VERTEX_INPUT_INSTANCE_ID
+    	uint inst : SV_InstanceID;
+		UNITY_VERTEX_INPUT_INSTANCE_ID
     };
-	
+
 	struct ps_input
 	{
 		float4 pos : SV_POSITION;
@@ -54,16 +55,16 @@
 		UNITY_VERTEX_OUTPUT_STEREO
 	};
 
-	ps_input vert(vs_input input)
+	ps_input vert(vs_input i)
 	{
 		ps_input o;
 
-		UNITY_SETUP_INSTANCE_ID(input);
+		UNITY_SETUP_INSTANCE_ID(i);
 		UNITY_INITIALIZE_OUTPUT(ps_input, o);
 		UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
 
-		int qind = (input.id) / 6;
-		int vind = (input.id) % 6;
+		int qind = (i.id) / 6;
+		int vind = (i.id) % 6;
 
 		int v_offset[6];
 		v_offset[0] = 2;

--- a/Dev/Plugin/Assets/Effekseer/Materials/StandardShader.shader
+++ b/Dev/Plugin/Assets/Effekseer/Materials/StandardShader.shader
@@ -40,19 +40,30 @@
 	StructuredBuffer<SimpleVertex> buf_vertex;
 	float buf_offset;
 
+    struct vs_input
+    {
+    	uint id : SV_VertexID;
+        UNITY_VERTEX_INPUT_INSTANCE_ID
+    };
+	
 	struct ps_input
 	{
 		float4 pos : SV_POSITION;
 		float2 uv : TEXCOORD0;
 		float4 color : COLOR0;
+		UNITY_VERTEX_OUTPUT_STEREO
 	};
 
-	ps_input vert(uint id : SV_VertexID, uint inst : SV_InstanceID)
+	ps_input vert(vs_input input)
 	{
 		ps_input o;
 
-		int qind = (id) / 6;
-		int vind = (id) % 6;
+		UNITY_SETUP_INSTANCE_ID(input);
+		UNITY_INITIALIZE_OUTPUT(ps_input, o);
+		UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+
+		int qind = (input.id) / 6;
+		int vind = (input.id) % 6;
 
 		int v_offset[6];
 		v_offset[0] = 2;

--- a/Dev/Plugin/Assets/Effekseer/Materials/StandardShader.shader
+++ b/Dev/Plugin/Assets/Effekseer/Materials/StandardShader.shader
@@ -40,12 +40,12 @@
 	StructuredBuffer<SimpleVertex> buf_vertex;
 	float buf_offset;
 
-    struct vs_input
-    {
-    	uint id : SV_VertexID;
-    	uint inst : SV_InstanceID;
+	struct vs_input
+	{
+		uint id : SV_VertexID;
+		uint inst : SV_InstanceID;
 		UNITY_VERTEX_INPUT_INSTANCE_ID
-    };
+	};
 
 	struct ps_input
 	{

--- a/Dev/Plugin/Assets/Effekseer/Scripts/EffekseerRendererUnity.cs
+++ b/Dev/Plugin/Assets/Effekseer/Scripts/EffekseerRendererUnity.cs
@@ -1071,7 +1071,7 @@ namespace Effekseer.Internal
 				else
 				{
 					path.commandBuffer.Blit(BuiltinRenderTextureType.CameraTarget, path.renderTexture.renderTexture);
-					path.commandBuffer.SetRenderTarget(BuiltinRenderTextureType.CameraTarget);
+					path.commandBuffer.SetRenderTarget(BuiltinRenderTextureType.CameraTarget, 0, CubemapFace.Unknown, -1);
 				}
 			}
 


### PR DESCRIPTION
Fix https://github.com/effekseer/EffekseerForUnity/issues/54 for standard effect shaders

Note: Distortion is not yet supported