### PR TITLE
fix: supress URP warning message

### DIFF
--- a/Dev/Plugin/Assets/Effekseer/External/URP/Effekseer.URP.asmdef
+++ b/Dev/Plugin/Assets/Effekseer/External/URP/Effekseer.URP.asmdef
@@ -17,6 +17,11 @@
             "name": "com.unity.render-pipelines.universal",
             "expression": "",
             "define": "EFFEKSEER_URP_SUPPORT"
+        },
+        {
+            "name": "com.unity.render-pipelines.universal",
+            "expression": "10.1",
+            "define": "EFFEKSEER_URP_DEPTHTARGET_FIX"
         }
     ],
     "noEngineReferences": false

--- a/Dev/Plugin/Assets/Effekseer/External/URP/EffekseerURPRenderPassFeature.cs
+++ b/Dev/Plugin/Assets/Effekseer/External/URP/EffekseerURPRenderPassFeature.cs
@@ -8,25 +8,13 @@ public class EffekseerURPRenderPassFeature : ScriptableRendererFeature
 {
 	class EffekseerRenderPassURP : UnityEngine.Rendering.Universal.ScriptableRenderPass
 	{
-		RenderTargetIdentifier cameraColorTarget;
-		RenderTargetIdentifier cameraDepthTarget;
-
 		Effekseer.Internal.RenderTargetProperty prop = new Effekseer.Internal.RenderTargetProperty();
 
-		public EffekseerRenderPassURP(RenderTargetIdentifier cameraColorTarget, RenderTargetIdentifier cameraDepthTarget)
+		public EffekseerRenderPassURP()
 		{
-			// HACK
-			bool isValidDepth = !cameraDepthTarget.ToString().Contains("-1");
-
-			this.cameraColorTarget = cameraColorTarget;
-			prop.colorTargetIdentifier = cameraColorTarget;
 			this.renderPassEvent = UnityEngine.Rendering.Universal.RenderPassEvent.AfterRenderingTransparents;
-
-			if(isValidDepth)
-			{
-				this.cameraDepthTarget = cameraDepthTarget;
-				prop.depthTargetIdentifier = cameraDepthTarget;
-			}
+			prop.colorTargetIdentifier = colorAttachment;
+			prop.depthTargetIdentifier = depthAttachment;
 		}
 
 		public override void Execute(ScriptableRenderContext context, ref UnityEngine.Rendering.Universal.RenderingData renderingData)
@@ -55,7 +43,7 @@ public class EffekseerURPRenderPassFeature : ScriptableRendererFeature
 
 	public override void AddRenderPasses(ScriptableRenderer renderer, ref RenderingData renderingData)
 	{
-		m_ScriptablePass = new EffekseerRenderPassURP(renderer.cameraColorTarget, renderer.cameraDepth);
+		m_ScriptablePass = new EffekseerRenderPassURP();
 		m_ScriptablePass.renderPassEvent = RenderPassEvent.AfterRenderingTransparents;
 		renderer.EnqueuePass(m_ScriptablePass);
 

--- a/Dev/Plugin/Assets/Effekseer/External/URP/EffekseerURPRenderPassFeature.cs
+++ b/Dev/Plugin/Assets/Effekseer/External/URP/EffekseerURPRenderPassFeature.cs
@@ -11,6 +11,8 @@ public class EffekseerURPRenderPassFeature : ScriptableRendererFeature
 #if !EFFEKSEER_URP_DEPTHTARGET_FIX
 		RenderTargetIdentifier cameraColorTarget;
 		RenderTargetIdentifier cameraDepthTarget;
+#else
+		ScriptableRenderer renderer;
 #endif
 		Effekseer.Internal.RenderTargetProperty prop = new Effekseer.Internal.RenderTargetProperty();
 
@@ -31,16 +33,20 @@ public class EffekseerURPRenderPassFeature : ScriptableRendererFeature
 			}
 		}
 #else
-		public EffekseerRenderPassURP()
+		public EffekseerRenderPassURP(ScriptableRenderer renderer)
 		{
-			prop.colorTargetIdentifier = colorAttachment;
-            prop.depthTargetIdentifier = depthAttachment;
+			this.renderer = renderer;
+			this.renderPassEvent = UnityEngine.Rendering.Universal.RenderPassEvent.AfterRenderingTransparents;
 		}
 #endif
 
 		public override void Execute(ScriptableRenderContext context, ref UnityEngine.Rendering.Universal.RenderingData renderingData)
 		{
 			if (Effekseer.EffekseerSystem.Instance == null) return;
+#if EFFEKSEER_URP_DEPTHTARGET_FIX
+			prop.colorTargetIdentifier = this.renderer.cameraColorTarget;
+			prop.depthTargetIdentifier = this.renderer.cameraDepthTarget;
+#endif
 			prop.colorTargetDescriptor = renderingData.cameraData.cameraTargetDescriptor;
 			prop.isRequiredToCopyBackground = true;
 			prop.renderFeature = Effekseer.Internal.RenderFeature.URP;
@@ -69,7 +75,7 @@ public class EffekseerURPRenderPassFeature : ScriptableRendererFeature
 		m_ScriptablePass.renderPassEvent = RenderPassEvent.AfterRenderingTransparents;
 		renderer.EnqueuePass(m_ScriptablePass);
 #else
-		m_ScriptablePass = new EffekseerRenderPassURP();
+		m_ScriptablePass = new EffekseerRenderPassURP(renderer);
 		m_ScriptablePass.renderPassEvent = RenderPassEvent.AfterRenderingTransparents;
 		renderer.EnqueuePass(m_ScriptablePass);
 #endif

--- a/Dev/Plugin/Assets/Effekseer/External/URP/EffekseerURPRenderPassFeature.cs
+++ b/Dev/Plugin/Assets/Effekseer/External/URP/EffekseerURPRenderPassFeature.cs
@@ -8,13 +8,25 @@ public class EffekseerURPRenderPassFeature : ScriptableRendererFeature
 {
 	class EffekseerRenderPassURP : UnityEngine.Rendering.Universal.ScriptableRenderPass
 	{
+		RenderTargetIdentifier cameraColorTarget;
+		RenderTargetIdentifier cameraDepthTarget;
+
 		Effekseer.Internal.RenderTargetProperty prop = new Effekseer.Internal.RenderTargetProperty();
 
-		public EffekseerRenderPassURP()
+		public EffekseerRenderPassURP(RenderTargetIdentifier cameraColorTarget, RenderTargetIdentifier cameraDepthTarget)
 		{
+			// HACK
+			bool isValidDepth = !cameraDepthTarget.ToString().Contains("-1");
+
+			this.cameraColorTarget = cameraColorTarget;
+			prop.colorTargetIdentifier = cameraColorTarget;
 			this.renderPassEvent = UnityEngine.Rendering.Universal.RenderPassEvent.AfterRenderingTransparents;
-			prop.colorTargetIdentifier = colorAttachment;
-			prop.depthTargetIdentifier = depthAttachment;
+
+			if(isValidDepth)
+			{
+				this.cameraDepthTarget = cameraDepthTarget;
+				prop.depthTargetIdentifier = cameraDepthTarget;
+			}
 		}
 
 		public override void Execute(ScriptableRenderContext context, ref UnityEngine.Rendering.Universal.RenderingData renderingData)
@@ -43,7 +55,7 @@ public class EffekseerURPRenderPassFeature : ScriptableRendererFeature
 
 	public override void AddRenderPasses(ScriptableRenderer renderer, ref RenderingData renderingData)
 	{
-		m_ScriptablePass = new EffekseerRenderPassURP();
+		m_ScriptablePass = new EffekseerRenderPassURP(renderer.cameraColorTarget, renderer.cameraDepth);
 		m_ScriptablePass.renderPassEvent = RenderPassEvent.AfterRenderingTransparents;
 		renderer.EnqueuePass(m_ScriptablePass);
 

--- a/Dev/Plugin/Assets/Effekseer/External/URP/EffekseerURPRenderPassFeature.cs
+++ b/Dev/Plugin/Assets/Effekseer/External/URP/EffekseerURPRenderPassFeature.cs
@@ -8,11 +8,13 @@ public class EffekseerURPRenderPassFeature : ScriptableRendererFeature
 {
 	class EffekseerRenderPassURP : UnityEngine.Rendering.Universal.ScriptableRenderPass
 	{
+#if !EFFEKSEER_URP_DEPTHTARGET_FIX
 		RenderTargetIdentifier cameraColorTarget;
 		RenderTargetIdentifier cameraDepthTarget;
-
+#endif
 		Effekseer.Internal.RenderTargetProperty prop = new Effekseer.Internal.RenderTargetProperty();
 
+#if !EFFEKSEER_URP_DEPTHTARGET_FIX
 		public EffekseerRenderPassURP(RenderTargetIdentifier cameraColorTarget, RenderTargetIdentifier cameraDepthTarget)
 		{
 			// HACK
@@ -28,6 +30,13 @@ public class EffekseerURPRenderPassFeature : ScriptableRendererFeature
 				prop.depthTargetIdentifier = cameraDepthTarget;
 			}
 		}
+#else
+		public EffekseerRenderPassURP()
+		{
+			prop.colorTargetIdentifier = colorAttachment;
+            prop.depthTargetIdentifier = depthAttachment;
+		}
+#endif
 
 		public override void Execute(ScriptableRenderContext context, ref UnityEngine.Rendering.Universal.RenderingData renderingData)
 		{
@@ -55,10 +64,15 @@ public class EffekseerURPRenderPassFeature : ScriptableRendererFeature
 
 	public override void AddRenderPasses(ScriptableRenderer renderer, ref RenderingData renderingData)
 	{
+#if !EFFEKSEER_URP_DEPTHTARGET_FIX
 		m_ScriptablePass = new EffekseerRenderPassURP(renderer.cameraColorTarget, renderer.cameraDepth);
 		m_ScriptablePass.renderPassEvent = RenderPassEvent.AfterRenderingTransparents;
 		renderer.EnqueuePass(m_ScriptablePass);
-
+#else
+		m_ScriptablePass = new EffekseerRenderPassURP();
+		m_ScriptablePass.renderPassEvent = RenderPassEvent.AfterRenderingTransparents;
+		renderer.EnqueuePass(m_ScriptablePass);
+#endif
 	}
 }
 


### PR DESCRIPTION
https://forum.unity.com/threads/warning-in-editor-you-can-only-call-cameradepthtarget-inside-the-scope-of-a-scriptableren.1028794/

URP10.5.1にて、こちらの警告が出ていたので、ScriptableRendererからRenderTargetIdentifierを取得するのではなく、ScriptableRendererPassの中で取得するように修正してみました。