### PR TITLE
Fix the bug that ignored depth texture in vr rendering for 16x

### DIFF
--- a/Dev/Plugin/Assets/Effekseer/External/URP/EffekseerURPRenderPassFeature.cs
+++ b/Dev/Plugin/Assets/Effekseer/External/URP/EffekseerURPRenderPassFeature.cs
@@ -45,7 +45,7 @@ public class EffekseerURPRenderPassFeature : ScriptableRendererFeature
 #if EFFEKSEER_URP_DEPTHTARGET_FIX
 			prop.colorTargetIdentifier = this.renderer.cameraColorTarget;
 
-			bool isValidDepth = !this.renderer.cameraDepthTarget.ToString().Contains("-1");
+			var isValidDepth = renderingData.cameraData.cameraType != CameraType.SceneView;
 
 			if (isValidDepth)
 			{


### PR DESCRIPTION
https://github.com/effekseer/EffekseerForUnity/pull/79 の向き先を16xに切り替えたPRです。
VR環境下にて、深度バッファが正常にレンダリングされない問題を修正します。