### PR TITLE
新しいバージョンのUnityで削除されたプロパティを参照していたバグの対応

### DIFF
--- a/Dev/Plugin/Assets/Effekseer/External/URP/EffekseerURPRenderPassFeature.cs
+++ b/Dev/Plugin/Assets/Effekseer/External/URP/EffekseerURPRenderPassFeature.cs
@@ -106,16 +106,25 @@ public class EffekseerURPRenderPassFeature : ScriptableRendererFeature
 			if (Effekseer.EffekseerSystem.Instance == null) return;
 #if EFFEKSEER_URP_DEPTHTARGET_FIX
 			var renderer = renderingData.cameraData.renderer;
+#if UNITY_2022_3_OR_NEWER
+			prop.colorTargetIdentifier = renderer.cameraColorTargetHandle;
+#else
 			prop.colorTargetIdentifier = renderer.cameraColorTarget;
+#endif
 
 			// NOTE: We need to know whether the depth in cameraDepthTarget is valid or not since if it is valid,
 			//       we need to pass cameraDepthTarget to SetRenderTarget() later on. If it isn't valid, the depth in
 			//       cameraColorTarget is used instead.
-			var isValidDepth = IsValidCameraDepthTarget(renderer.cameraDepthTarget);
+#if UNITY_2022_3_OR_NEWER
+			var cameraDepthTarget = renderer.cameraDepthTargetHandle;
+#else
+			var cameraDepthTarget = renderer.cameraDepthTarget;
+#endif
+			var isValidDepth = IsValidCameraDepthTarget(cameraDepthTarget);
 
 			if (isValidDepth)
 			{
-				prop.depthTargetIdentifier = renderer.cameraDepthTarget;
+				prop.depthTargetIdentifier = cameraDepthTarget;
 			}
 			else
 			{


### PR DESCRIPTION
表題の通りの変更です。

URP対応をした際に、Unity2022でObsoleteに変更され、Unity2023で削除されたプロパティを使用している箇所を、新しいバージョンのプロパティに変更しています。