### PR TITLE
SinglePass Instanced XR 環境で Disrtortion, Depth オプションを有効化して正常に描画できる

### DIFF
--- a/Dev/Plugin/Assets/Effekseer/External/URP/EffekseerURPRenderPassFeature.cs
+++ b/Dev/Plugin/Assets/Effekseer/External/URP/EffekseerURPRenderPassFeature.cs
@@ -12,32 +12,32 @@ using UnityEngine.Rendering.RenderGraphModule;
 
 public class UrpBlitter : IEffekseerBlitter
 {
-	public static readonly int sourceTex = Shader.PropertyToID("_SourceTex");
-	private Material blitMaterial;
-
-	public UrpBlitter()
-	{
-		this.blitMaterial = CoreUtils.CreateEngineMaterial("Hidden/Universal Render Pipeline/Blit");
-	}
-
 	public void Blit(CommandBuffer cmd, RenderTargetIdentifier source, RenderTargetIdentifier dest, bool xrRendering)
 	{
 		if (xrRendering)
 		{
-			CoreUtils.SetRenderTarget(
-				cmd,
-				dest,
-				RenderBufferLoadAction.Load,
-				RenderBufferStoreAction.Store,
-				ClearFlag.None,
-				Color.black);
-			cmd.SetGlobalTexture(sourceTex, source);
-			cmd.DrawProcedural(Matrix4x4.identity, blitMaterial, 0, MeshTopology.Quads, 4);
+			CoreUtils.SetRenderTarget(cmd, dest);
+			Blitter.BlitTexture(cmd, source, Vector2.one, Blitter.GetBlitMaterial(TextureXR.dimension), 0);
 		}
 		else
 		{
 			cmd.Blit(source, dest);
 		}
+	}
+
+	public void Blit(CommandBuffer cmd, RenderTargetIdentifier source, RenderTargetIdentifier dest, Material material, bool xrRendering)
+	{
+		cmd.Blit(source, dest, material);
+	}
+
+	public void SetRenderTarget(CommandBuffer cmd, RenderTargetIdentifier color, bool xrRendering)
+	{
+		CoreUtils.SetRenderTarget(cmd, color);
+	}
+
+	public void SetRenderTarget(CommandBuffer cmd, RenderTargetIdentifier color, RenderTargetIdentifier depth, bool xrRendering)
+	{
+		CoreUtils.SetRenderTarget(cmd, color, depth);
 	}
 }
 

--- a/Dev/Plugin/Assets/Effekseer/Scripts/EffekseerBlitter.cs
+++ b/Dev/Plugin/Assets/Effekseer/Scripts/EffekseerBlitter.cs
@@ -1,10 +1,14 @@
-﻿using UnityEngine.Rendering;
+﻿using UnityEngine;
+using UnityEngine.Rendering;
 
 namespace Effekseer.Internal
 {
 	public interface IEffekseerBlitter
 	{
 		void Blit(CommandBuffer cmd, RenderTargetIdentifier source, RenderTargetIdentifier dest, bool xrRendering);
+		void Blit(CommandBuffer cmd, RenderTargetIdentifier source, RenderTargetIdentifier dest, Material material, bool xrRendering);
+		void SetRenderTarget(CommandBuffer cmd, RenderTargetIdentifier color, bool xrRendering);
+		void SetRenderTarget(CommandBuffer cmd, RenderTargetIdentifier color, RenderTargetIdentifier depth, bool xrRendering);
 	}
 
 	public class StandardBlitter : IEffekseerBlitter
@@ -12,6 +16,35 @@ namespace Effekseer.Internal
 		public void Blit(CommandBuffer cmd, RenderTargetIdentifier source, RenderTargetIdentifier dest, bool xrRendering)
 		{
 			cmd.Blit(source, dest);
+		}
+
+		public void Blit(CommandBuffer cmd, RenderTargetIdentifier source, RenderTargetIdentifier dest, Material material, bool xrRendering)
+		{
+			cmd.Blit(source, dest, material);
+		}
+
+		public void SetRenderTarget(CommandBuffer cmd, RenderTargetIdentifier color, bool xrRendering)
+		{
+			if (xrRendering)
+			{
+				cmd.SetRenderTarget(color, 0, CubemapFace.Unknown, -1);
+			}
+			else
+			{
+				cmd.SetRenderTarget(color);
+			}
+		}
+
+		public void SetRenderTarget(CommandBuffer cmd, RenderTargetIdentifier color, RenderTargetIdentifier depth, bool xrRendering)
+		{
+			if (xrRendering)
+			{
+				cmd.SetRenderTarget(color, depth, 0, CubemapFace.Unknown, -1);
+			}
+			else
+			{
+				cmd.SetRenderTarget(color, depth);
+			}
 		}
 	}
 }

--- a/Dev/Plugin/Assets/Effekseer/Scripts/EffekseerRenderer.cs
+++ b/Dev/Plugin/Assets/Effekseer/Scripts/EffekseerRenderer.cs
@@ -125,7 +125,7 @@ namespace Effekseer.Internal
 				{
 					if (canGrabDepth)
 					{
-						blitter.Blit(cb, RenderTargetIdentifier.Invalid, depthRenderTexture.renderTexture, grabDepthMat);
+						blitter.Blit(cb, new RenderTargetIdentifier(), depthRenderTexture.renderTexture, grabDepthMat);
 					}
 					else
 					{

--- a/Dev/Plugin/Assets/Effekseer/Scripts/EffekseerRenderer.cs
+++ b/Dev/Plugin/Assets/Effekseer/Scripts/EffekseerRenderer.cs
@@ -100,7 +100,7 @@ namespace Effekseer.Internal
 		{
 		}
 
-		internal void ApplyToCommandBuffer(CommandBuffer cb, DepthRenderTexture depthRenderTexture)
+		internal void ApplyToCommandBuffer(CommandBuffer cb, DepthRenderTexture depthRenderTexture, IEffekseerBlitter blitter)
 		{
 			if (depthRenderTexture != null)
 			{
@@ -125,11 +125,11 @@ namespace Effekseer.Internal
 				{
 					if (canGrabDepth)
 					{
-						cb.Blit(null, depthRenderTexture.renderTexture, grabDepthMat);
+						blitter.Blit(cb, RenderTargetIdentifier.Invalid, depthRenderTexture.renderTexture, grabDepthMat);
 					}
 					else
 					{
-						cb.SetRenderTarget(depthRenderTexture.renderTexture);
+						blitter.SetRenderTarget(cb, depthRenderTexture.renderTexture, xrRendering);
 						cb.ClearRenderTarget(true, true, new Color(0, 0, 0));
 					}
 				}
@@ -154,11 +154,11 @@ namespace Effekseer.Internal
 				// restore
 				if (depthTargetIdentifier.HasValue)
 				{
-					cb.SetRenderTarget(colorTargetIdentifier, depthTargetIdentifier.Value);
+					blitter.SetRenderTarget(cb, colorTargetIdentifier, depthTargetIdentifier.Value, xrRendering);
 				}
 				else
 				{
-					cb.SetRenderTarget(colorTargetIdentifier);
+					blitter.SetRenderTarget(cb, colorTargetIdentifier, xrRendering);
 				}
 			}
 		}
@@ -176,9 +176,9 @@ namespace Effekseer.Internal
 						Viewport.height / colorTargetRenderTexture.height,
 						Viewport.x / colorTargetRenderTexture.width,
 						Viewport.y / colorTargetRenderTexture.height));
-					cb.SetRenderTarget(backgroundRenderTexture.renderTexture);
+					blitter.SetRenderTarget(cb, backgroundRenderTexture.renderTexture, xrRendering);
 					cb.ClearRenderTarget(true, true, new Color(0, 0, 0));
-					cb.Blit(colorTargetIdentifier, backgroundRenderTexture.renderTexture, m);
+					blitter.Blit(cb, colorTargetIdentifier, backgroundRenderTexture.renderTexture, m, xrRendering);
 				}
 				else
 				{
@@ -189,9 +189,9 @@ namespace Effekseer.Internal
 						Viewport.height / colorTargetRenderTexture.height,
 						Viewport.x / colorTargetRenderTexture.width,
 						Viewport.y / colorTargetRenderTexture.height));
-					cb.SetRenderTarget(backgroundRenderTexture.renderTexture);
+					blitter.SetRenderTarget(cb, backgroundRenderTexture.renderTexture, xrRendering);
 					cb.ClearRenderTarget(true, true, new Color(0, 0, 0));
-					cb.Blit(colorTargetIdentifier, backgroundRenderTexture.renderTexture, m);
+					blitter.Blit(cb, colorTargetIdentifier, backgroundRenderTexture.renderTexture, m, xrRendering);
 				}
 			}
 			else if (isRequiredToCopyBackground)
@@ -206,11 +206,11 @@ namespace Effekseer.Internal
 			// restore
 			if (depthTargetIdentifier.HasValue)
 			{
-				cb.SetRenderTarget(colorTargetIdentifier, depthTargetIdentifier.Value);
+				blitter.SetRenderTarget(cb, colorTargetIdentifier, depthTargetIdentifier.Value, xrRendering);
 			}
 			else
 			{
-				cb.SetRenderTarget(colorTargetIdentifier);
+				blitter.SetRenderTarget(cb, colorTargetIdentifier, xrRendering);
 			}
 		}
 

--- a/Dev/Plugin/Assets/Effekseer/Scripts/EffekseerRendererNative.cs
+++ b/Dev/Plugin/Assets/Effekseer/Scripts/EffekseerRendererNative.cs
@@ -161,7 +161,7 @@ namespace Effekseer.Internal
 				{
 					if (renderTargetProperty != null)
 					{
-						renderTargetProperty.ApplyToCommandBuffer(cmbBuf, this.depthTexture);
+						renderTargetProperty.ApplyToCommandBuffer(cmbBuf, this.depthTexture, blitter);
 
 						if (renderTargetProperty.Viewport.width > 0)
 						{

--- a/Dev/Plugin/Assets/Effekseer/Scripts/EffekseerRendererUnity.cs
+++ b/Dev/Plugin/Assets/Effekseer/Scripts/EffekseerRendererUnity.cs
@@ -1209,7 +1209,7 @@ namespace Effekseer.Internal
 					bool xrRendering = false;
 
 					blitter.Blit(path.commandBuffer, BuiltinRenderTextureType.CameraTarget, path.renderTexture.renderTexture, xrRendering);
-					path.commandBuffer.SetRenderTarget(BuiltinRenderTextureType.CameraTarget, 0, CubemapFace.Unknown, -1);
+					blitter.SetRenderTarget(path.commandBuffer, BuiltinRenderTextureType.CameraTarget, xrRendering);
 				}
 			}
 
@@ -1217,7 +1217,7 @@ namespace Effekseer.Internal
 			{
 				if (renderTargetProperty != null)
 				{
-					renderTargetProperty.ApplyToCommandBuffer(path.commandBuffer, path.depthTexture);
+					renderTargetProperty.ApplyToCommandBuffer(path.commandBuffer, path.depthTexture, blitter);
 
 					if (renderTargetProperty.Viewport.width > 0)
 					{
@@ -1230,7 +1230,7 @@ namespace Effekseer.Internal
 					bool xrRendering = false;
 
 					blitter.Blit(path.commandBuffer, BuiltinRenderTextureType.Depth, path.depthTexture.renderTexture, xrRendering);
-					path.commandBuffer.SetRenderTarget(BuiltinRenderTextureType.CameraTarget, 0, CubemapFace.Unknown, -1);
+					blitter.SetRenderTarget(path.commandBuffer, BuiltinRenderTextureType.CameraTarget, xrRendering);
 				}
 			}
 
@@ -1261,7 +1261,7 @@ namespace Effekseer.Internal
 				if (renderTargetProperty != null && renderTargetProperty.colorBufferID.HasValue)
 				{
 					blitter.Blit(path.commandBuffer, renderTargetProperty.colorBufferID.Value, path.renderTexture.renderTexture, renderTargetProperty.xrRendering);
-					path.commandBuffer.SetRenderTarget(renderTargetProperty.colorBufferID.Value, 0, CubemapFace.Unknown, -1);
+					blitter.SetRenderTarget(path.commandBuffer, renderTargetProperty.colorBufferID.Value, renderTargetProperty.xrRendering);
 
 					if (renderTargetProperty.Viewport.width > 0)
 					{
@@ -1283,7 +1283,7 @@ namespace Effekseer.Internal
 					bool xrRendering = false;
 
 					blitter.Blit(path.commandBuffer, BuiltinRenderTextureType.CameraTarget, path.renderTexture.renderTexture, xrRendering);
-					path.commandBuffer.SetRenderTarget(BuiltinRenderTextureType.CameraTarget, 0, CubemapFace.Unknown, -1);
+					blitter.SetRenderTarget(path.commandBuffer, BuiltinRenderTextureType.CameraTarget, xrRendering);
 				}
 			}
 


### PR DESCRIPTION
<img width="1030" alt="image" src="https://github.com/user-attachments/assets/9adc4754-971b-45c0-ab3e-fe1aab509e0a" />


## 動作確認環境
次の組み合わせで EfkBasic シーンの動作を確認しました。

- Unity Version
  - Unity 2022.3 LTS
  - Unity 6.0
- Render Pipeline 
  - Built-in RP
  - URP (Unity 6 では CompatibleMode/RenderGraph どちらも）
- XR
  - None
  - Multi Pass
  - Single Pass Instanced 
- EffekseerSettings
  - Renderer Type
    - ~Native~ (XR は非対応とする)
    - Unity
  - Enable Distortion
    - ON/OFF
  - Enable Depth
    - ON/OFF

- `IEffekseerBlitter` interface に `SetRenderTexture()` を追加
    - URP 利用下において `com.unity.render-pipelines.core` Package の `CoreUtils.SetRenderTarget()` を用いたいため
        - 理由は後述

`EffekseerRenderer` では `CommandBuffer.SetRenderTarget()` が用いられている。
とくに Depth や Distortion 利用時は、エフェクト描画直前に元のカラーターゲットバッファに戻すために用いられている。
この引数に渡すために `TextureHandle colorTargetIdentifier` が implicit cast により `RTHandle`, `RenderTargetIdentifier` にキャストされている。
この際 `RTHandle` 内で生成されている `RenderTargetIdentifier` が `depthSlice` を考慮せず初期値の `0` となっている。

ここで Unity6 や Unity 2022.3 の URP + SinglePass Instanced XR 環境においてはカラーターゲットバッファがテクスチャの配列であるため、index が `0` の左目だけに結果が描画されてしまう、というバグが起きていた。

このあたりのハンドリングは RenderGraph においてはガラッと変わっているが、それに追従するには全体の刷新が必要なので本 PullReq では行わない。
Effekseer は UnsafePass が使われていることもあり、本 PullReq ではRTHandle System 時代の解決法をとり、`CoreUtils.SetRenderTarget()` を使う。
この関数はデフォルト引数として `depthSlice` が `-1` 、つまりテクスチャ配列のすべてのテクスチャを対象とする