### PR TITLE
Update effekseer 1803

### DIFF
--- a/Dev/Cpp/renderer/EffekseerRendererImplemented.cpp
+++ b/Dev/Cpp/renderer/EffekseerRendererImplemented.cpp
@@ -293,10 +293,7 @@ void ModelRenderer::EndRendering(const efkModelNodeParam& parameter, void* userD
 			state.TextureWrapTypes[i] = collector_.TextureWrapTypes[i];
 		}
 
-		if (textureCount > 0)
-		{
-			renderer_->SetTextures(nullptr, textures.data(), textureCount);
-		}
+		renderer_->SetTextures(nullptr, textures.data(), textureCount);
 
 		if (parameter.BasicParameterPtr->MaterialType == Effekseer::RendererMaterialType::File)
 		{
@@ -1014,6 +1011,10 @@ void RendererImplemented::DrawModel(Effekseer::ModelRef model,
 		modelParameter.VColor[2] = colors[i].B / 255.0f;
 		modelParameter.VColor[3] = colors[i].A / 255.0f;
 		modelParameter.Time = times[i] % model_->GetFrameCount();
+		if (modelParameter.Time < 0)
+		{
+			modelParameter.Time += model_->GetFrameCount();
+		}
 		AddInfoBuffer(&modelParameter, sizeof(UnityModelParameter1));
 	}
 
@@ -1097,10 +1098,11 @@ void RendererImplemented::SetPixelBufferToShader(const void* data, int32_t size,
 
 void RendererImplemented::SetTextures(Shader* shader, Effekseer::Backend::TextureRef* textures, int32_t count)
 {
-	textures_.resize(count);
-	if (count > 0)
+	const auto textureCount = count < static_cast<int32_t>(Effekseer::TextureSlotMax) ? count : static_cast<int32_t>(Effekseer::TextureSlotMax);
+	textures_.resize(textureCount);
+	if (textureCount > 0)
 	{
-		for (int i = 0; i < count; i++)
+		for (int i = 0; i < textureCount; i++)
 		{
 			if (textures[i] != nullptr)
 			{

--- a/Dev/Cpp/renderer/EffekseerRendererImplemented.h
+++ b/Dev/Cpp/renderer/EffekseerRendererImplemented.h
@@ -38,7 +38,7 @@ extern "C"
 
 	struct EdgeParameters
 	{
-		std::array<float, 4> Color;
+		std::array<float, 4> Color{};
 		float Threshold = 0;
 		float ColorScaling = 1;
 	};
@@ -46,8 +46,8 @@ extern "C"
 	struct FalloffParameter
 	{
 		int32_t ColorBlendType = 0;
-		std::array<float, 4> BeginColor;
-		std::array<float, 4> EndColor;
+		std::array<float, 4> BeginColor{};
+		std::array<float, 4> EndColor{};
 		float Pow = 1.0f;
 	};
 
@@ -87,12 +87,12 @@ extern "C"
 		float EmissiveScaling = 1;
 		EdgeParameters EdgeParams;
 
-		std::array<float, 4> SoftParticleParam;
-		std::array<float, 4> ReconstrcutionParam1;
-		std::array<float, 4> ReconstrcutionParam2;
+		std::array<float, 4> SoftParticleParam{};
+		std::array<float, 4> ReconstrcutionParam1{};
+		std::array<float, 4> ReconstrcutionParam2{};
 
 		//! For a material
-		std::array<float, 4> PredefinedUniform;
+		std::array<float, 4> PredefinedUniform{};
 
 		int ZTest = 0;
 
@@ -108,11 +108,11 @@ extern "C"
 		int IsRefraction = 0;
 
 		//! Texture ptr
-		std::array<void*, Effekseer::TextureSlotMax> TexturePtrs;
+		std::array<void*, Effekseer::TextureSlotMax> TexturePtrs{};
 
-		std::array<int, Effekseer::TextureSlotMax> TextureFilterTypes;
+		std::array<int, Effekseer::TextureSlotMax> TextureFilterTypes{};
 
-		std::array<int, Effekseer::TextureSlotMax> TextureWrapTypes;
+		std::array<int, Effekseer::TextureSlotMax> TextureWrapTypes{};
 
 		int32_t TextureCount = 0;
 
@@ -124,7 +124,7 @@ extern "C"
 	};
 
 	UNITY_INTERFACE_EXPORT void UNITY_INTERFACE_API GetUnityRenderParameter(UnityRenderParameter* dst, int index);
-	UNITY_INTERFACE_EXPORT int UNITY_INTERFACE_API GetUnityRenderCount();
+	UNITY_INTERFACE_EXPORT int UNITY_INTERFACE_API GetUnityRenderParameterCount();
 	UNITY_INTERFACE_EXPORT void* UNITY_INTERFACE_API GetUnityVertexBuffer();
 	UNITY_INTERFACE_EXPORT void* UNITY_INTERFACE_API GetUnityInfoBuffer();
 

--- a/Dev/Cpp/renderer/EffekseerRendererImplemented.h
+++ b/Dev/Cpp/renderer/EffekseerRendererImplemented.h
@@ -294,7 +294,7 @@ protected:
 		dst.UVDistortionUV = EffekseerRenderer::GetVertexUVDistortionUV(v);
 		dst.BlendUV = EffekseerRenderer::GetVertexBlendUV(v);
 		dst.BlendAlphaUV = EffekseerRenderer::GetVertexBlendAlphaUV(v);
-		dst.BlendUVDistortionUV = EffekseerRenderer::GetVertexUVDistortionUV(v);
+		dst.BlendUVDistortionUV = EffekseerRenderer::GetVertexBlendUVDistortionUV(v);
 		dst.FlipbookIndexAndNextRate = EffekseerRenderer::GetVertexFlipbookIndexAndNextRate(v);
 		dst.AlphaThreshold = EffekseerRenderer::GetVertexAlphaThreshold(v);
 		strideBuffer.PushBuffer(&dst, sizeof(AdvancedVertexParameter));

--- a/Dev/Cpp/renderer/EffekseerRendererMaterialLoader.cpp
+++ b/Dev/Cpp/renderer/EffekseerRendererMaterialLoader.cpp
@@ -73,10 +73,10 @@ Effekseer::MaterialRef MaterialLoader::Load(const EFK_CHAR* path)
 
 		materialData->IsSimpleVertex = material->GetIsSimpleVertex();
 		materialData->IsRefractionRequired = material->GetHasRefraction();
-		materialData->CustomData1 = material->GetCustomData1Count();
-		materialData->CustomData2 = material->GetCustomData2Count();
+		materialData->CustomData1 = std::min(std::max(material->GetCustomData1Count(), 0), 4);
+		materialData->CustomData2 = std::min(std::max(material->GetCustomData2Count(), 0), 4);
 		materialData->TextureCount = std::min(material->GetTextureCount(), Effekseer::UserTextureSlotMax);
-		materialData->UniformCount = material->GetUniformCount();
+		materialData->UniformCount = std::min(material->GetUniformCount(), Effekseer::UserUniformSlotMax);
 		materialData->ShadingModel = material->GetShadingModel();
 
 		for (int32_t i = 0; i < materialData->TextureCount; i++)

--- a/Dev/Plugin/Assets/Effekseer/Editor/EffekseerAssetPostProcessor.cs
+++ b/Dev/Plugin/Assets/Effekseer/Editor/EffekseerAssetPostProcessor.cs
@@ -95,7 +95,8 @@ namespace Effekseer.Editor
 						var tp = new EffekseerMaterialAsset.TextureProperty();
 						tp.Name = t.Name;
 						tp.UniformName = t.UniformName;
-						tp.Type = (EffekseerMaterialAsset.TextureType)EffekseerTool.Utl.TextureType.Color;
+						tp.Type = (EffekseerMaterialAsset.TextureType)t.Type;
+						tp.Index = t.Index;
 						importingAsset.Textures.Add(tp);
 					}
 

--- a/Dev/Plugin/Assets/Effekseer/Editor/EffekseerAssetPostProcessor.cs
+++ b/Dev/Plugin/Assets/Effekseer/Editor/EffekseerAssetPostProcessor.cs
@@ -32,188 +32,209 @@ namespace Effekseer.Editor
 			string[] movedAssets,
 			string[] movedFromPaths)
 		{
-			// Hack for EffekseerMaterial
+			AttachShadersToImportedMaterialAssets(importedAssets);
 
-			if (importedAssets.Any(_ => System.IO.Path.GetExtension(_) == ".asset"))
+			// Effects resolve generated Effekseer assets by path, so create those assets first.
+			foreach (string assetPath in importedAssets)
 			{
-				foreach (string assetPath in importedAssets)
-				{
-					if (Path.GetExtension(assetPath) == ".asset")
-					{
-						var asset = AssetDatabase.LoadAssetAtPath<EffekseerMaterialAsset>(assetPath);
-
-						if (asset != null)
-						{
-							asset.AttachShader(assetPath);
-						}
-					}
-				}
+				ImportResourceAsset(assetPath);
 			}
 
 			foreach (string assetPath in importedAssets)
 			{
-				if (Path.GetExtension(assetPath) == ".efk")
+				ImportEffectAsset(assetPath);
+			}
+		}
+
+		static void AttachShadersToImportedMaterialAssets(string[] importedAssets)
+		{
+			// Hack for EffekseerMaterial
+			if (!importedAssets.Any(_ => IsExtension(_, ".asset")))
+			{
+				return;
+			}
+
+			foreach (string assetPath in importedAssets)
+			{
+				if (!IsExtension(assetPath, ".asset"))
 				{
-					EffekseerEffectAsset.CreateAsset(assetPath);
+					continue;
 				}
-				if (Path.GetExtension(assetPath) == ".efkmodel")
+
+				var asset = AssetDatabase.LoadAssetAtPath<EffekseerMaterialAsset>(assetPath);
+
+				if (asset != null)
 				{
-					EffekseerModelAsset.CreateAsset(assetPath);
-				}
-				if (Path.GetExtension(assetPath) == ".efkcurve")
-				{
-					EffekseerCurveAsset.CreateAsset(assetPath);
-				}
-					if (Path.GetExtension(assetPath) == ".efkmat")
-					{
-						EffekseerMaterialAsset.ImportingAsset importingAsset = new EffekseerMaterialAsset.ImportingAsset();
-						importingAsset.Data = System.IO.File.ReadAllBytes(assetPath);
-						importingAsset.UserTextureSlotMax = EffekseerTool.Constant.UserTextureSlotCount;
-						var info = new Effekseer.Editor.Utils.MaterialInformation();
-						if (!info.Load(System.IO.Path.Combine(System.IO.Directory.GetCurrentDirectory(), assetPath)))
-						{
-							UnityEngine.Debug.LogError("Failed to load Effekseer material: " + assetPath);
-							continue;
-						}
-
-					importingAsset.CustomData1Count = info.CustomData1Count;
-					importingAsset.CustomData2Count = info.CustomData2Count;
-					importingAsset.HasRefraction = info.HasRefraction;
-					importingAsset.ShadingModel = info.ShadingModel;
-
-					foreach (var u in info.Uniforms)
-					{
-						var up = new EffekseerMaterialAsset.UniformProperty();
-						up.Name = u.Name;
-						up.UniformName = u.UniformName;
-						up.Count = u.Type;
-						importingAsset.Uniforms.Add(up);
-					}
-
-					foreach (var t in info.Textures)
-					{
-						var tp = new EffekseerMaterialAsset.TextureProperty();
-						tp.Name = t.Name;
-						tp.UniformName = t.UniformName;
-						tp.Type = (EffekseerMaterialAsset.TextureType)t.Type;
-						tp.Index = t.Index;
-						importingAsset.Textures.Add(tp);
-					}
-
-					// TODO : Refactor
-					foreach (var g in info.FixedGradients)
-					{
-						var gp = new EffekseerMaterialAsset.GradientProperty();
-						gp.Name = g.Name;
-						gp.UniformName = g.UniformName;
-
-						gp.ColorMarkers = new EffekseerMaterialAsset.GradientProperty.ColorMarker[g.Data.ColorMarkers.Length];
-						for (int i = 0; i < g.Data.ColorMarkers.Length; i++)
-						{
-							gp.ColorMarkers[i].ColorR = g.Data.ColorMarkers[i].ColorR;
-							gp.ColorMarkers[i].ColorG = g.Data.ColorMarkers[i].ColorG;
-							gp.ColorMarkers[i].ColorB = g.Data.ColorMarkers[i].ColorB;
-							gp.ColorMarkers[i].Intensity = g.Data.ColorMarkers[i].Intensity;
-							gp.ColorMarkers[i].Position = g.Data.ColorMarkers[i].Position;
-						}
-
-						gp.AlphaMarkers = new EffekseerMaterialAsset.GradientProperty.AlphaMarker[g.Data.AlphaMarkers.Length];
-						for (int i = 0; i < g.Data.AlphaMarkers.Length; i++)
-						{
-							gp.AlphaMarkers[i].Alpha = g.Data.AlphaMarkers[i].Alpha;
-							gp.AlphaMarkers[i].Position = g.Data.AlphaMarkers[i].Position;
-						}
-
-						importingAsset.FixedGradients.Add(gp);
-					}
-
-					foreach (var g in info.Gradients)
-					{
-						var gp = new EffekseerMaterialAsset.GradientProperty();
-						gp.Name = g.Name;
-						gp.UniformName = g.UniformName;
-
-						gp.ColorMarkers = new EffekseerMaterialAsset.GradientProperty.ColorMarker[g.Data.ColorMarkers.Length];
-						for (int i = 0; i < g.Data.ColorMarkers.Length; i++)
-						{
-							gp.ColorMarkers[i].ColorR = g.Data.ColorMarkers[i].ColorR;
-							gp.ColorMarkers[i].ColorG = g.Data.ColorMarkers[i].ColorG;
-							gp.ColorMarkers[i].ColorB = g.Data.ColorMarkers[i].ColorB;
-							gp.ColorMarkers[i].Intensity = g.Data.ColorMarkers[i].Intensity;
-							gp.ColorMarkers[i].Position = g.Data.ColorMarkers[i].Position;
-						}
-
-						gp.AlphaMarkers = new EffekseerMaterialAsset.GradientProperty.AlphaMarker[g.Data.AlphaMarkers.Length];
-						for (int i = 0; i < g.Data.AlphaMarkers.Length; i++)
-						{
-							gp.AlphaMarkers[i].Alpha = g.Data.AlphaMarkers[i].Alpha;
-							gp.AlphaMarkers[i].Position = g.Data.AlphaMarkers[i].Position;
-						}
-
-						importingAsset.Gradients.Add(gp);
-					}
-
-					importingAsset.IsCacheFile = false;
-					importingAsset.Code = info.Code;
-
-					importingAsset.MaterialRequiredFunctionTypes = new EffekseerMaterialAsset.MaterialRequiredFunctionType[info.RequiredFunctionTypes.Length];
-					for (int i = 0; i < importingAsset.MaterialRequiredFunctionTypes.Length; i++)
-					{
-						importingAsset.MaterialRequiredFunctionTypes[i] = (EffekseerMaterialAsset.MaterialRequiredFunctionType)info.RequiredFunctionTypes[i];
-					}
-
-					EffekseerMaterialAsset.CreateAsset(assetPath, importingAsset);
-				}
-				if (Path.GetExtension(assetPath) == ".efkmatd")
-				{
-					EffekseerMaterialAsset.ImportingAsset importingAsset = new EffekseerMaterialAsset.ImportingAsset();
-					importingAsset.Data = System.IO.File.ReadAllBytes(assetPath);
-					importingAsset.IsCacheFile = true;
-
-					EffekseerMaterialAsset.CreateAsset(assetPath, importingAsset);
-				}
-				if (Path.GetExtension(assetPath) == ".efkproj" || Path.GetExtension(assetPath) == ".efkefc")
-				{
-					var fullpath = System.IO.Path.GetFullPath(assetPath);
-					if (!System.IO.File.Exists(fullpath)) return;
-					var allData = System.IO.File.ReadAllBytes(fullpath);
-
-					if (allData.Length < 24) return;
-
-					if (allData[0] != 'E' ||
-						allData[1] != 'F' ||
-						allData[2] != 'K' ||
-						allData[3] != 'E')
-					{
-						// Before 1.5
-						if (EffekseerTool.Core.LoadFrom(assetPath))
-						{
-							var exporter = new EffekseerTool.Binary.Exporter();
-							var data = exporter.Export(1);
-							EffekseerEffectAsset.CreateAsset(assetPath, data);
-						}
-					}
-					else
-					{
-						// After 1.5
-						var version = System.BitConverter.ToInt32(allData, 4);
-
-						var chunkData = allData.Skip(8).ToArray();
-
-						var chunk = new EffekseerTool.IO.Chunk();
-						chunk.Load(chunkData);
-
-						var binBlock = chunk.Blocks.FirstOrDefault(_ => _.Chunk == "BIN_");
-						if (binBlock == null)
-						{
-							return;
-						}
-
-						EffekseerEffectAsset.CreateAsset(assetPath, binBlock.Buffer);
-					}
-
+					asset.AttachShader(assetPath);
 				}
 			}
+		}
+
+		static void ImportResourceAsset(string assetPath)
+		{
+			if (IsExtension(assetPath, ".efkmodel"))
+			{
+				EffekseerModelAsset.CreateAsset(assetPath);
+			}
+			else if (IsExtension(assetPath, ".efkcurve"))
+			{
+				EffekseerCurveAsset.CreateAsset(assetPath);
+			}
+			else if (IsExtension(assetPath, ".efkmat"))
+			{
+				ImportMaterialAsset(assetPath);
+			}
+			else if (IsExtension(assetPath, ".efkmatd"))
+			{
+				EffekseerMaterialAsset.ImportingAsset importingAsset = new EffekseerMaterialAsset.ImportingAsset();
+				importingAsset.Data = System.IO.File.ReadAllBytes(assetPath);
+				importingAsset.IsCacheFile = true;
+
+				EffekseerMaterialAsset.CreateAsset(assetPath, importingAsset);
+			}
+		}
+
+		static void ImportEffectAsset(string assetPath)
+		{
+			if (IsExtension(assetPath, ".efk"))
+			{
+				EffekseerEffectAsset.CreateAsset(assetPath);
+			}
+			else if (IsExtension(assetPath, ".efkproj") || IsExtension(assetPath, ".efkefc"))
+			{
+				ImportProjectAsset(assetPath);
+			}
+		}
+
+		static void ImportMaterialAsset(string assetPath)
+		{
+			EffekseerMaterialAsset.ImportingAsset importingAsset = new EffekseerMaterialAsset.ImportingAsset();
+			importingAsset.Data = System.IO.File.ReadAllBytes(assetPath);
+			importingAsset.UserTextureSlotMax = EffekseerTool.Constant.UserTextureSlotCount;
+			var info = new Effekseer.Editor.Utils.MaterialInformation();
+			if (!info.Load(System.IO.Path.Combine(System.IO.Directory.GetCurrentDirectory(), assetPath)))
+			{
+				UnityEngine.Debug.LogError("Failed to load Effekseer material: " + assetPath);
+				return;
+			}
+
+			importingAsset.CustomData1Count = info.CustomData1Count;
+			importingAsset.CustomData2Count = info.CustomData2Count;
+			importingAsset.HasRefraction = info.HasRefraction;
+			importingAsset.ShadingModel = info.ShadingModel;
+
+			foreach (var u in info.Uniforms)
+			{
+				var up = new EffekseerMaterialAsset.UniformProperty();
+				up.Name = u.Name;
+				up.UniformName = u.UniformName;
+				up.Count = u.Type;
+				importingAsset.Uniforms.Add(up);
+			}
+
+			foreach (var t in info.Textures)
+			{
+				var tp = new EffekseerMaterialAsset.TextureProperty();
+				tp.Name = t.Name;
+				tp.UniformName = t.UniformName;
+				tp.Type = (EffekseerMaterialAsset.TextureType)t.Type;
+				tp.Index = t.Index;
+				importingAsset.Textures.Add(tp);
+			}
+
+			// TODO : Refactor
+			foreach (var g in info.FixedGradients)
+			{
+				var gp = CreateGradientProperty(g);
+				importingAsset.FixedGradients.Add(gp);
+			}
+
+			foreach (var g in info.Gradients)
+			{
+				var gp = CreateGradientProperty(g);
+				importingAsset.Gradients.Add(gp);
+			}
+
+			importingAsset.IsCacheFile = false;
+			importingAsset.Code = info.Code;
+
+			importingAsset.MaterialRequiredFunctionTypes = new EffekseerMaterialAsset.MaterialRequiredFunctionType[info.RequiredFunctionTypes.Length];
+			for (int i = 0; i < importingAsset.MaterialRequiredFunctionTypes.Length; i++)
+			{
+				importingAsset.MaterialRequiredFunctionTypes[i] = (EffekseerMaterialAsset.MaterialRequiredFunctionType)info.RequiredFunctionTypes[i];
+			}
+
+			EffekseerMaterialAsset.CreateAsset(assetPath, importingAsset);
+		}
+
+		static EffekseerMaterialAsset.GradientProperty CreateGradientProperty(Utils.MaterialInformation.GradientInformation g)
+		{
+			var gp = new EffekseerMaterialAsset.GradientProperty();
+			gp.Name = g.Name;
+			gp.UniformName = g.UniformName;
+
+			gp.ColorMarkers = new EffekseerMaterialAsset.GradientProperty.ColorMarker[g.Data.ColorMarkers.Length];
+			for (int i = 0; i < g.Data.ColorMarkers.Length; i++)
+			{
+				gp.ColorMarkers[i].ColorR = g.Data.ColorMarkers[i].ColorR;
+				gp.ColorMarkers[i].ColorG = g.Data.ColorMarkers[i].ColorG;
+				gp.ColorMarkers[i].ColorB = g.Data.ColorMarkers[i].ColorB;
+				gp.ColorMarkers[i].Intensity = g.Data.ColorMarkers[i].Intensity;
+				gp.ColorMarkers[i].Position = g.Data.ColorMarkers[i].Position;
+			}
+
+			gp.AlphaMarkers = new EffekseerMaterialAsset.GradientProperty.AlphaMarker[g.Data.AlphaMarkers.Length];
+			for (int i = 0; i < g.Data.AlphaMarkers.Length; i++)
+			{
+				gp.AlphaMarkers[i].Alpha = g.Data.AlphaMarkers[i].Alpha;
+				gp.AlphaMarkers[i].Position = g.Data.AlphaMarkers[i].Position;
+			}
+
+			return gp;
+		}
+
+		static void ImportProjectAsset(string assetPath)
+		{
+			var fullpath = System.IO.Path.GetFullPath(assetPath);
+			if (!System.IO.File.Exists(fullpath)) return;
+			var allData = System.IO.File.ReadAllBytes(fullpath);
+
+			if (allData.Length < 24) return;
+
+			if (allData[0] != 'E' ||
+				allData[1] != 'F' ||
+				allData[2] != 'K' ||
+				allData[3] != 'E')
+			{
+				// Before 1.5
+				if (EffekseerTool.Core.LoadFrom(assetPath))
+				{
+					var exporter = new EffekseerTool.Binary.Exporter();
+					var data = exporter.Export(1);
+					EffekseerEffectAsset.CreateAsset(assetPath, data);
+				}
+			}
+			else
+			{
+				// After 1.5
+				var chunkData = allData.Skip(8).ToArray();
+
+				var chunk = new EffekseerTool.IO.Chunk();
+				chunk.Load(chunkData);
+
+				var binBlock = chunk.Blocks.FirstOrDefault(_ => _.Chunk == "BIN_");
+				if (binBlock == null)
+				{
+					return;
+				}
+
+				EffekseerEffectAsset.CreateAsset(assetPath, binBlock.Buffer);
+			}
+		}
+
+		static bool IsExtension(string path, string extension)
+		{
+			return string.Equals(Path.GetExtension(path), extension, System.StringComparison.OrdinalIgnoreCase);
 		}
 	}
 }

--- a/Dev/Plugin/Assets/Effekseer/Materials/EffekseerShaderAdVS.cginc
+++ b/Dev/Plugin/Assets/Effekseer/Materials/EffekseerShaderAdVS.cginc
@@ -501,6 +501,7 @@ VS_Output vert(VS_Input i)
 	Input_Internal.Alpha_Dist_UV.zw = buf_ad[buf_ad_offset + qind * 4 + v_offset[vind]].UVDistortionUV;
 	Input_Internal.BlendUV = buf_ad[buf_ad_offset + qind * 4 + v_offset[vind]].BlendUV;
 	Input_Internal.Blend_Alpha_Dist_UV.xy = buf_ad[buf_ad_offset + qind * 4 + v_offset[vind]].BlendAlphaUV;
+	Input_Internal.Blend_Alpha_Dist_UV.zw = buf_ad[buf_ad_offset + qind * 4 + v_offset[vind]].BlendUVDistortionUV;
 	Input_Internal.FlipbookIndex = buf_ad[buf_ad_offset + qind * 4 + v_offset[vind]].FlipbookIndexAndNextRate;
 	Input_Internal.AlphaThreshold = buf_ad[buf_ad_offset + qind * 4 + v_offset[vind]].AlphaThreshold;
 

--- a/Dev/Plugin/Assets/Effekseer/Scripts/EffekseerMaterialAsset.cs
+++ b/Dev/Plugin/Assets/Effekseer/Scripts/EffekseerMaterialAsset.cs
@@ -205,13 +205,23 @@ namespace Effekseer
 			// modifiy importing asset to avoid invalid name
 			foreach (var texture in importingAsset.Textures)
 			{
-				if (texture.Name == string.Empty)
+				if (string.IsNullOrEmpty(texture.UniformName))
 				{
-					texture.Name = texture.UniformName;
+					texture.UniformName = texture.Name;
 				}
 
 				// Escape
-				texture.Name = EscapePropertyName(texture.Name);
+				texture.Name = EscapePropertyName(texture.UniformName);
+			}
+
+			foreach (var uniform in importingAsset.Uniforms)
+			{
+				if (string.IsNullOrEmpty(uniform.UniformName))
+				{
+					uniform.UniformName = uniform.Name;
+				}
+
+				uniform.Name = uniform.UniformName;
 			}
 
 			string assetPath = Path.ChangeExtension(path, ".asset");
@@ -984,7 +994,7 @@ Cull[_Cull]
 			if(opacityMask <= 0.0) discard;
 			if(opacity <= 0.0) discard;
 		
-			return Output;
+			return ConvertToScreen(Output);
 
 			@else
 

--- a/Dev/Plugin/Assets/Effekseer/Scripts/EffekseerMaterialAsset.cs
+++ b/Dev/Plugin/Assets/Effekseer/Scripts/EffekseerMaterialAsset.cs
@@ -50,6 +50,9 @@ namespace Effekseer
 {
 	public partial class EffekseerMaterialAsset : ScriptableObject
 	{
+		public const int UserUniformSlotMax = 16;
+		public const int UserTextureSlotMax = 6;
+
 		[System.Serializable]
 		public enum TextureType
 		{
@@ -129,7 +132,7 @@ namespace Effekseer
 			public bool IsCacheFile = false;
 			public int CustomData1Count = 0;
 			public int CustomData2Count = 0;
-			public int UserTextureSlotMax = 6;
+			public int UserTextureSlotMax = EffekseerMaterialAsset.UserTextureSlotMax;
 			public bool HasRefraction = false;
 			public List<TextureProperty> Textures = new List<TextureProperty>();
 			public List<UniformProperty> Uniforms = new List<UniformProperty>();
@@ -304,12 +307,13 @@ namespace Effekseer
 			baseCode = baseCode.Replace("$F2$", "float2");
 			baseCode = baseCode.Replace("$F3$", "float3");
 			baseCode = baseCode.Replace("$F4$", "float4");
-				baseCode = baseCode.Replace("$TIME$", "_Time.y");
-				baseCode = baseCode.Replace("$EFFECTSCALE$", "predefined_uniform.y");
-				baseCode = baseCode.Replace("$LOCALTIME$", "predefined_uniform.w");
-				baseCode = baseCode.Replace("$PARTICLE_TIME_NORMALIZED$", "particleTime.x");
-				baseCode = baseCode.Replace("$PARTICLE_TIME_SECONDS$", "particleTime.y");
-				baseCode = baseCode.Replace("$UV$", "uv");
+			baseCode = baseCode.Replace("$TIME$", "predefined_uniform.x");
+			baseCode = baseCode.Replace("$EFFECTSCALE$", "predefined_uniform.y");
+			baseCode = baseCode.Replace("$LOCALTIME$", "predefined_uniform.w");
+			baseCode = baseCode.Replace("$PARTICLE_TIME_NORMALIZED$", "particleTime.x");
+			baseCode = baseCode.Replace("$PARTICLE_TIME_SECONDS$", "particleTime.y");
+			baseCode = baseCode.Replace("$UV$", "uv");
+			baseCode = baseCode.Replace("$MOD", "fmod");
 
 			int actualTextureCount = Math.Min(importingAsset.UserTextureSlotMax, importingAsset.Textures.Count);
 
@@ -409,7 +413,8 @@ namespace Effekseer
 
 			foreach (var gradient in importingAsset.FixedGradients)
 			{
-				functions += ShaderGenerator.GetFixedGradient(gradient.Name, gradient);
+				var gradientName = string.IsNullOrEmpty(gradient.UniformName) ? gradient.Name : gradient.UniformName;
+				functions += ShaderGenerator.GetFixedGradient(gradientName, gradient);
 			}
 
 			code += shaderTemplate;
@@ -420,6 +425,7 @@ namespace Effekseer
 			string codeUniforms = string.Empty;
 
 			int actualTextureCount = Math.Min(importingAsset.UserTextureSlotMax, importingAsset.Textures.Count);
+			int actualUniformCount = Math.Min(UserUniformSlotMax, importingAsset.Uniforms.Count);
 
 			for (int i = 0; i < actualTextureCount; i++)
 			{
@@ -427,9 +433,14 @@ namespace Effekseer
 				codeVariable += "sampler2D " + importingAsset.Textures[i].Name + ";" + nl;
 			}
 
-			for (int i = 0; i < importingAsset.Uniforms.Count; i++)
+			for (int i = 0; i < actualUniformCount; i++)
 			{
 				codeUniforms += "float4 " + importingAsset.Uniforms[i].Name + ";" + nl;
+			}
+
+			for (int i = actualUniformCount; i < importingAsset.Uniforms.Count; i++)
+			{
+				codeUniforms += "const float4 " + importingAsset.Uniforms[i].Name + " = float4(0,0,0,0);" + nl;
 			}
 
 			for (int i = 0; i < importingAsset.Gradients.Count; i++)

--- a/Dev/Plugin/Assets/Effekseer/Scripts/EffekseerMaterialAsset.cs
+++ b/Dev/Plugin/Assets/Effekseer/Scripts/EffekseerMaterialAsset.cs
@@ -68,6 +68,9 @@ namespace Effekseer
 
 			[SerializeField]
 			public string UniformName;
+
+			[SerializeField]
+			public int Index = -1;
 		}
 
 		[System.Serializable]
@@ -312,8 +315,9 @@ namespace Effekseer
 
 			for (int i = 0; i < actualTextureCount; i++)
 			{
-				var keyP = "$TEX_P" + i + "$";
-				var keyS = "$TEX_S" + i + "$";
+				var textureIndex = importingAsset.Textures[i].Index >= 0 ? importingAsset.Textures[i].Index : i;
+				var keyP = "$TEX_P" + textureIndex + "$";
+				var keyS = "$TEX_S" + textureIndex + "$";
 
 				var replacedP = string.Empty;
 				var replacedS = string.Empty;
@@ -343,8 +347,9 @@ namespace Effekseer
 			// invalid texture
 			for (int i = actualTextureCount; i < importingAsset.Textures.Count; i++)
 			{
-				var keyP = "$TEX_P" + i + "$";
-				var keyS = "$TEX_S" + i + "$";
+				var textureIndex = importingAsset.Textures[i].Index >= 0 ? importingAsset.Textures[i].Index : i;
+				var keyP = "$TEX_P" + textureIndex + "$";
+				var keyS = "$TEX_S" + textureIndex + "$";
 				baseCode = baseCode.Replace(keyP, "float4(");
 				baseCode = baseCode.Replace(keyS, ",0.0,1.0)");
 			}

--- a/Dev/Plugin/Assets/Effekseer/Scripts/EffekseerMaterialAsset.cs
+++ b/Dev/Plugin/Assets/Effekseer/Scripts/EffekseerMaterialAsset.cs
@@ -180,6 +180,24 @@ namespace Effekseer
 			return "_" + name + "_Tex";
 		}
 
+		static int ClampCustomDataCount(int count)
+		{
+			return Math.Min(4, Math.Max(0, count));
+		}
+
+		static string GetFloatType(int count)
+		{
+			return count <= 1 ? "float" : "float" + count.ToString();
+		}
+
+		static string GetElementSelector(int count)
+		{
+			if (count <= 1) return ".x";
+			if (count == 2) return ".xy";
+			if (count == 3) return ".xyz";
+			return ".xyzw";
+		}
+
 		/// <summary>
 		/// to avoid unity bug
 		/// </summary>
@@ -196,11 +214,8 @@ namespace Effekseer
 		public static void CreateAsset(string path, ImportingAsset importingAsset)
 		{
 			// modify
-			if (importingAsset.CustomData1Count > 0)
-				importingAsset.CustomData1Count = Math.Max(2, importingAsset.CustomData1Count);
-
-			if (importingAsset.CustomData2Count > 0)
-				importingAsset.CustomData2Count = Math.Max(2, importingAsset.CustomData2Count);
+			importingAsset.CustomData1Count = ClampCustomDataCount(importingAsset.CustomData1Count);
+			importingAsset.CustomData2Count = ClampCustomDataCount(importingAsset.CustomData2Count);
 
 			// modifiy importing asset to avoid invalid name
 			foreach (var texture in importingAsset.Textures)
@@ -283,18 +298,18 @@ namespace Effekseer
 				if (importingAsset.CustomData1Count > 0)
 				{
 					baseCode += "#if _MODEL_\n";
-					baseCode += string.Format("float4 customData1 = buf_customData1[inst];\n");
+					baseCode += string.Format("{0} customData1 = buf_customData1[inst]{1};\n", GetFloatType(importingAsset.CustomData1Count), GetElementSelector(importingAsset.CustomData1Count));
 					baseCode += "#else\n";
-					baseCode += string.Format("float{0} customData1 = Input.CustomData1;\n", importingAsset.CustomData1Count);
+					baseCode += string.Format("{0} customData1 = Input.CustomData1;\n", GetFloatType(importingAsset.CustomData1Count));
 					baseCode += "#endif\n";
 				}
 
 				if (importingAsset.CustomData2Count > 0)
 				{
 					baseCode += "#if _MODEL_\n";
-					baseCode += string.Format("float4 customData2 = buf_customData2[inst];\n");
+					baseCode += string.Format("{0} customData2 = buf_customData2[inst]{1};\n", GetFloatType(importingAsset.CustomData2Count), GetElementSelector(importingAsset.CustomData2Count));
 					baseCode += "#else\n";
-					baseCode += string.Format("float{0} customData2 = Input.CustomData2;\n", importingAsset.CustomData2Count);
+					baseCode += string.Format("{0} customData2 = Input.CustomData2;\n", GetFloatType(importingAsset.CustomData2Count));
 					baseCode += "#endif\n";
 				}
 			}
@@ -302,12 +317,12 @@ namespace Effekseer
 			{
 				if (importingAsset.CustomData1Count > 0)
 				{
-					baseCode += string.Format("float{0} customData1 = Input.CustomData1;", importingAsset.CustomData1Count);
+					baseCode += string.Format("{0} customData1 = Input.CustomData1;", GetFloatType(importingAsset.CustomData1Count));
 				}
 
 				if (importingAsset.CustomData2Count > 0)
 				{
-					baseCode += string.Format("float{0} customData2 = Input.CustomData2;", importingAsset.CustomData2Count);
+					baseCode += string.Format("{0} customData2 = Input.CustomData2;", GetFloatType(importingAsset.CustomData2Count));
 				}
 			}
 
@@ -504,15 +519,15 @@ namespace Effekseer
 			if (importingAsset.CustomData1Count > 0)
 			{
 				code = code.Replace("//%CUSTOM_BUF1%", string.Format("StructuredBuffer<float4> buf_customData1;"));
-				code = code.Replace("//%CUSTOM_VS_INPUT1%", string.Format("float{0} CustomData1;", importingAsset.CustomData1Count));
-				code = code.Replace("//%CUSTOM_VSPS_INOUT1%", string.Format("float{0} CustomData1 : TEXCOORD8;", importingAsset.CustomData1Count));
+				code = code.Replace("//%CUSTOM_VS_INPUT1%", string.Format("{0} CustomData1;", GetFloatType(importingAsset.CustomData1Count)));
+				code = code.Replace("//%CUSTOM_VSPS_INOUT1%", string.Format("{0} CustomData1 : TEXCOORD8;", GetFloatType(importingAsset.CustomData1Count)));
 			}
 
 			if (importingAsset.CustomData2Count > 0)
 			{
 				code = code.Replace("//%CUSTOM_BUF2%", string.Format("StructuredBuffer<float4> buf_customData2;"));
-				code = code.Replace("//%CUSTOM_VS_INPUT2%", string.Format("float{0} CustomData2;", importingAsset.CustomData2Count));
-				code = code.Replace("//%CUSTOM_VSPS_INOUT2%", string.Format("float{0} CustomData2 : TEXCOORD9;", importingAsset.CustomData2Count));
+				code = code.Replace("//%CUSTOM_VS_INPUT2%", string.Format("{0} CustomData2;", GetFloatType(importingAsset.CustomData2Count)));
+				code = code.Replace("//%CUSTOM_VSPS_INOUT2%", string.Format("{0} CustomData2 : TEXCOORD9;", GetFloatType(importingAsset.CustomData2Count)));
 			}
 
 			// change return codes

--- a/Dev/Plugin/Assets/Effekseer/Scripts/EffekseerRenderer.cs
+++ b/Dev/Plugin/Assets/Effekseer/Scripts/EffekseerRenderer.cs
@@ -335,6 +335,18 @@ namespace Effekseer.Internal
 #endif
 			}
 		}
+
+		internal static void DestroyRenderTexture(RenderTexture renderTexture)
+		{
+#if UNITY_EDITOR
+			if (!Application.isPlaying)
+			{
+				UnityEngine.Object.DestroyImmediate(renderTexture);
+				return;
+			}
+#endif
+			UnityEngine.Object.Destroy(renderTexture);
+		}
 	}
 
 	internal class BackgroundRenderTexture
@@ -437,7 +449,7 @@ namespace Effekseer.Internal
 			if (renderTexture != null)
 			{
 				renderTexture.Release();
-				UnityEngine.Object.Destroy(renderTexture);
+				EffekseerRendererUtils.DestroyRenderTexture(renderTexture);
 				renderTexture = null;
 				ptr = IntPtr.Zero;
 			}
@@ -485,7 +497,7 @@ namespace Effekseer.Internal
 			if (renderTexture != null)
 			{
 				renderTexture.Release();
-				UnityEngine.Object.Destroy(renderTexture);
+				EffekseerRendererUtils.DestroyRenderTexture(renderTexture);
 				renderTexture = null;
 				ptr = IntPtr.Zero;
 			}

--- a/Dev/Plugin/Assets/Effekseer/Scripts/EffekseerRendererUnity.cs
+++ b/Dev/Plugin/Assets/Effekseer/Scripts/EffekseerRendererUnity.cs
@@ -1454,6 +1454,9 @@ namespace Effekseer.Internal
 			if (model == null)
 				return;
 
+			if (model.IndexCounts == null || model.IndexCounts.Count == 0)
+				return;
+
 			var count = parameter.ElementCount;
 			var offset = 0;
 
@@ -1463,7 +1466,15 @@ namespace Effekseer.Internal
 				ComputeBuffer computeBuf1 = null;
 				ComputeBuffer computeBuf2 = null;
 
-				var allocated = modelBufferCol1.Allocate(modelParameters1, modelParameters2, offset, count, ref computeBuf1, ref computeBuf2);
+				var frameIndex = GetModelFrameIndex(modelParameters1[offset].Time, model.IndexCounts.Count);
+				var renderCount = 1;
+				while (renderCount < count && GetModelFrameIndex(modelParameters1[offset + renderCount].Time, model.IndexCounts.Count) == frameIndex)
+				{
+					renderCount++;
+				}
+
+				var allocated = modelBufferCol1.Allocate(modelParameters1, modelParameters2, offset, renderCount, ref computeBuf1, ref computeBuf2);
+				var indexCount = model.IndexCounts[frameIndex];
 
 				var isAdvanced = parameter.MaterialType == Plugin.RendererMaterialType.AdvancedBackDistortion ||
 					parameter.MaterialType == Plugin.RendererMaterialType.AdvancedLit ||
@@ -1590,7 +1601,7 @@ namespace Effekseer.Internal
 					if (efkMaterial.asset.CustomData1Count > 0)
 					{
 						ComputeBuffer cb = null;
-						var all = customDataBuffers.Allocate((CustomDataBuffer*)((byte*)infoBuffer.ToPointer() + parameter.CustomData1BufferOffset), offset, count, ref cb);
+						var all = customDataBuffers.Allocate((CustomDataBuffer*)((byte*)infoBuffer.ToPointer() + parameter.CustomData1BufferOffset), offset, allocated, ref cb);
 						if (all != allocated) throw new Exception();
 						SetBufferProperty(commandBuffer, prop, "buf_customData1", cb);
 					}
@@ -1598,7 +1609,7 @@ namespace Effekseer.Internal
 					if (efkMaterial.asset.CustomData2Count > 0)
 					{
 						ComputeBuffer cb = null;
-						var all = customDataBuffers.Allocate((CustomDataBuffer*)((byte*)infoBuffer.ToPointer() + parameter.CustomData2BufferOffset), offset, count, ref cb);
+						var all = customDataBuffers.Allocate((CustomDataBuffer*)((byte*)infoBuffer.ToPointer() + parameter.CustomData2BufferOffset), offset, allocated, ref cb);
 						if (all != allocated) throw new Exception();
 						SetBufferProperty(commandBuffer, prop, "buf_customData2", cb);
 					}
@@ -1608,7 +1619,7 @@ namespace Effekseer.Internal
 						prop.SetTexture("_BackTex", GetCachedTexture(parameter.GetTexturePtr(actualTextureCount), background, depth, DummyTextureType.White));
 					}
 
-					commandBuffer.DrawProcedural(Matrix4x4.identity, material, 0, MeshTopology.Triangles, model.IndexCounts[0], allocated, prop);
+					commandBuffer.DrawProcedural(Matrix4x4.identity, material, 0, MeshTopology.Triangles, indexCount, allocated, prop);
 				}
 				else
 				{
@@ -1621,7 +1632,7 @@ namespace Effekseer.Internal
 						prop.SetVector("fLightDirection", EffekseerSystem.LightDirection.normalized);
 						prop.SetColor("fLightColor", EffekseerSystem.LightColor);
 						prop.SetColor("fLightAmbient", EffekseerSystem.LightAmbientColor);
-						commandBuffer.DrawProcedural(Matrix4x4.identity, material, 0, MeshTopology.Triangles, model.IndexCounts[0], allocated, prop);
+						commandBuffer.DrawProcedural(Matrix4x4.identity, material, 0, MeshTopology.Triangles, indexCount, allocated, prop);
 					}
 					else if (parameter.MaterialType == Plugin.RendererMaterialType.BackDistortion ||
 						parameter.MaterialType == Plugin.RendererMaterialType.AdvancedBackDistortion)
@@ -1629,12 +1640,12 @@ namespace Effekseer.Internal
 						prop.SetVector("g_scale", new Vector4(parameter.DistortionIntensity, 0.0f, 0.0f, 0.0f));
 						if (background != null)
 						{
-							commandBuffer.DrawProcedural(Matrix4x4.identity, material, 0, MeshTopology.Triangles, model.IndexCounts[0], allocated, prop);
+							commandBuffer.DrawProcedural(Matrix4x4.identity, material, 0, MeshTopology.Triangles, indexCount, allocated, prop);
 						}
 					}
 					else
 					{
-						commandBuffer.DrawProcedural(Matrix4x4.identity, material, 0, MeshTopology.Triangles, model.IndexCounts[0], allocated, prop);
+						commandBuffer.DrawProcedural(Matrix4x4.identity, material, 0, MeshTopology.Triangles, indexCount, allocated, prop);
 					}
 				}
 
@@ -1643,6 +1654,17 @@ namespace Effekseer.Internal
 				offset += allocated;
 				count -= allocated;
 			}
+		}
+
+		static int GetModelFrameIndex(int time, int frameCount)
+		{
+			var frameIndex = time % frameCount;
+			if (frameIndex < 0)
+			{
+				frameIndex += frameCount;
+			}
+
+			return frameIndex;
 		}
 
 		unsafe Texture GetAndApplyParameterToTexture(in Plugin.UnityRenderParameter parameter, int index, BackgroundRenderTexture background, DepthRenderTexture depth, DummyTextureType dummyTextureType)
@@ -1656,6 +1678,10 @@ namespace Effekseer.Internal
 			if (parameter.TextureWrapTypes[index] == 0)
 			{
 				texture.wrapMode = TextureWrapMode.Repeat;
+			}
+			else if (parameter.TextureWrapTypes[index] == 2)
+			{
+				texture.wrapMode = TextureWrapMode.Mirror;
 			}
 			else
 			{

--- a/Dev/Plugin/Assets/Effekseer/Scripts/EffekseerRendererUnity.cs
+++ b/Dev/Plugin/Assets/Effekseer/Scripts/EffekseerRendererUnity.cs
@@ -1346,10 +1346,11 @@ namespace Effekseer.Internal
 
 				prop.SetVector("lightDirection", EffekseerSystem.LightDirection.normalized);
 				prop.SetColor("lightColor", EffekseerSystem.LightColor);
-				prop.SetColor("lightAmbient", EffekseerSystem.LightAmbientColor);
+				prop.SetColor("lightAmbientColor", EffekseerSystem.LightAmbientColor);
 				prop.SetVector("predefined_uniform", parameter.PredefinedUniform);
 
-				for (int ti = 0; ti < efkMaterial.asset.textures.Length; ti++)
+				var actualTextureCount = Math.Min(EffekseerMaterialAsset.UserTextureSlotMax, efkMaterial.asset.textures.Length);
+				for (int ti = 0; ti < actualTextureCount; ti++)
 				{
 					var texture = GetAndApplyParameterToTexture(parameter, ti, background, depth, DummyTextureType.White);
 					if (texture != null)
@@ -1362,7 +1363,7 @@ namespace Effekseer.Internal
 
 				if (parameter.IsRefraction > 0 && background != null)
 				{
-					prop.SetTexture("_BackTex", GetCachedTexture(parameter.GetTexturePtr(efkMaterial.asset.textures.Length), background, depth, DummyTextureType.White));
+					prop.SetTexture("_BackTex", GetCachedTexture(parameter.GetTexturePtr(actualTextureCount), background, depth, DummyTextureType.White));
 				}
 
 				commandBuffer.DrawProcedural(Matrix4x4.identity, material, 0, MeshTopology.Triangles, parameter.ElementCount * 2 * 3, 1, prop);
@@ -1402,7 +1403,8 @@ namespace Effekseer.Internal
 		private static unsafe void AssignUniforms(Plugin.UnityRenderParameter parameter, IntPtr infoBuffer, MaterialPropertyBlock prop, UnityRendererMaterial efkMaterial)
 		{
 			int uniformOffset = 0;
-			for (int ui = 0; ui < efkMaterial.asset.uniforms.Length; ui++)
+			var actualUniformCount = Math.Min(EffekseerMaterialAsset.UserUniformSlotMax, efkMaterial.asset.uniforms.Length);
+			for (int ui = 0; ui < actualUniformCount; ui++)
 			{
 				var f = ((float*)(((byte*)infoBuffer.ToPointer()) + parameter.UniformBufferOffset));
 				prop.SetVector(efkMaterial.asset.uniforms[ui].Name, new Vector4(f[uniformOffset + 0], f[uniformOffset + 1], f[uniformOffset + 2], f[uniformOffset + 3]));
@@ -1569,10 +1571,11 @@ namespace Effekseer.Internal
 
 					prop.SetVector("lightDirection", EffekseerSystem.LightDirection.normalized);
 					prop.SetColor("lightColor", EffekseerSystem.LightColor);
-					prop.SetColor("lightAmbient", EffekseerSystem.LightAmbientColor);
+					prop.SetColor("lightAmbientColor", EffekseerSystem.LightAmbientColor);
 					prop.SetVector("predefined_uniform", parameter.PredefinedUniform);
 
-					for (int ti = 0; ti < efkMaterial.asset.textures.Length; ti++)
+					var actualTextureCount = Math.Min(EffekseerMaterialAsset.UserTextureSlotMax, efkMaterial.asset.textures.Length);
+					for (int ti = 0; ti < actualTextureCount; ti++)
 					{
 						var texture = GetAndApplyParameterToTexture(parameter, ti, background, depth, DummyTextureType.White);
 						if (texture != null)
@@ -1602,7 +1605,7 @@ namespace Effekseer.Internal
 
 					if (parameter.IsRefraction > 0 && background != null)
 					{
-						prop.SetTexture("_BackTex", GetCachedTexture(parameter.GetTexturePtr(efkMaterial.asset.textures.Length), background, depth, DummyTextureType.White));
+						prop.SetTexture("_BackTex", GetCachedTexture(parameter.GetTexturePtr(actualTextureCount), background, depth, DummyTextureType.White));
 					}
 
 					commandBuffer.DrawProcedural(Matrix4x4.identity, material, 0, MeshTopology.Triangles, model.IndexCounts[0], allocated, prop);

--- a/Dev/Plugin/Assets/Effekseer/Scripts/EffekseerRendererUnity.cs
+++ b/Dev/Plugin/Assets/Effekseer/Scripts/EffekseerRendererUnity.cs
@@ -965,7 +965,7 @@ namespace Effekseer.Internal
 			GetMaterialCollection(Plugin.RendererMaterialType.BackDistortion, true).Keywords = new string[] { "_MODEL_", "ENABLE_DISTORTION" };
 
 			GetMaterialCollection(Plugin.RendererMaterialType.Lit, false).Shader = EffekseerDependentAssets.Instance.fixedShader;
-			GetMaterialCollection(Plugin.RendererMaterialType.Lit, false).Keywords = new string[] { "_MODEL_" };
+			GetMaterialCollection(Plugin.RendererMaterialType.Lit, false).Keywords = new string[] { "ENABLE_LIGHTING" };
 			GetMaterialCollection(Plugin.RendererMaterialType.Lit, true).Shader = EffekseerDependentAssets.Instance.fixedShader;
 			GetMaterialCollection(Plugin.RendererMaterialType.Lit, true).Keywords = new string[] { "_MODEL_", "ENABLE_LIGHTING" };
 
@@ -1559,20 +1559,11 @@ namespace Effekseer.Internal
 
 					if (parameter.IsRefraction > 0)
 					{
-						if (efkMaterial.materialsRefraction == null)
+						if (efkMaterial.materialsModelRefraction == null)
 						{
 							return;
 						}
 
-						material = efkMaterial.materialsRefraction.GetMaterial(ref key);
-					}
-					else
-					{
-						material = efkMaterial.materials.GetMaterial(ref key);
-					}
-
-					if (parameter.IsRefraction > 0)
-					{
 						material = efkMaterial.materialsModelRefraction.GetMaterial(ref key);
 					}
 					else


### PR DESCRIPTION
### 不具合修正内容

master との差分では、Effekseer 1.80.3 更新に伴うUnity描画・マテリアル生成まわりの不具合を修正しています。

- マテリアル生成時のテクスチャ/Uniformスロット数を上限内に制限し、範囲外アクセスや不正なシェーダ生成を防止
- CustomData数を0-4にクランプし、`float` / `float2` / `float3` / `float4` が正しく生成されるよう修正
- テクスチャの `Type` / `Index` / `UniformName` を正しく引き継ぎ、マテリアル内の参照先ずれを修正
- `$TIME$`、`$MOD`、固定Gradient、スクリーン座標変換など、生成シェーダ内の置換・出力処理を修正
- Unity描画側でテクスチャ/Uniformの適用数を上限内に制限し、リフラクション用背景テクスチャの参照スロットを修正
- ライティング用プロパティ名とキーワード設定を修正し、Lit描画の反映漏れを修正
- モデル描画でフレームごとのIndex数を使うようにし、負の時間・空Index・複数フレーム混在時の描画崩れを修正
- モデルのリフラクション描画で、モデル用リフラクションマテリアルを参照するよう修正
- Mirror wrap modeに対応し、テクスチャのラップ設定が正しく反映されるよう修正
- Advanced描画のBlend UV Distortionが通常UV Distortionを参照していた問題を修正
- ネイティブ側でテクスチャ数・Uniform数・CustomData数を上限内に制限し、未初期化値や古いテクスチャ状態が残る問題を防止
- Effekseer本体サブモジュールを更新し、Metal/DX9/WebGPU、シェーダ、Gradient、SIMD、レンダラー関連の修正を取り込み
- インポート周りを修正 